### PR TITLE
update to PHPStan 1.0 and fix new errors

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,11 +13,11 @@
     "minimum-stability": "dev",
     "require": {
         "php": ">=7.2.0",
-        "phpstan/phpstan": "^0.12",
+        "phpstan/phpstan": "^1.0",
         "cakephp/cakephp": "^4.0.0"
     },
     "require-dev": {
-        "phpstan/phpstan-phpunit": "^0.12",
+        "phpstan/phpstan-phpunit": "^1.0",
         "phpunit/phpunit": "^8.5",
         "squizlabs/php_codesniffer": "3.*"
     },

--- a/src/Traits/BaseCakeRegistryReturnTrait.php
+++ b/src/Traits/BaseCakeRegistryReturnTrait.php
@@ -37,11 +37,11 @@ trait BaseCakeRegistryReturnTrait
         string $defaultClass,
         string $namespaceFormat
     ) {
-        if (\count($methodCall->args) === 0) {
+        if (\count($methodCall->getArgs()) === 0) {
             return ParametersAcceptorSelector::selectSingle($methodReflection->getVariants())->getReturnType();
         }
 
-        $argType = $scope->getType($methodCall->args[0]->value);
+        $argType = $scope->getType($methodCall->getArgs()[0]->value);
         if (!method_exists($argType, 'getValue')) {
             return new ObjectType($defaultClass);
         }

--- a/tests/test_app/Command/MyTestLoadCommand.php
+++ b/tests/test_app/Command/MyTestLoadCommand.php
@@ -26,6 +26,6 @@ class MyTestLoadCommand extends Command
         $article = $this->loadModel('VeryCustomize00009Articles')
             ->newSample();
 
-        $io->out($article->get('title'));
+        $io->out(strval($article->get('title')));
     }
 }

--- a/tests/test_plugin/Model/Table/HelloWorld101010ArticlesTable.php
+++ b/tests/test_plugin/Model/Table/HelloWorld101010ArticlesTable.php
@@ -35,7 +35,7 @@ class HelloWorld101010ArticlesTable extends Table
     }
 
     /**
-     * @return \Cake\Datasource\EntityInterface|array<\Cake\Datasource\EntityInterface>
+     * @return \Cake\Datasource\EntityInterface|array<string, mixed>
      */
     public function getLatestOne()
     {

--- a/tests/test_plugin/Model/Table/HelloWorld101010ArticlesTable.php
+++ b/tests/test_plugin/Model/Table/HelloWorld101010ArticlesTable.php
@@ -35,15 +35,10 @@ class HelloWorld101010ArticlesTable extends Table
     }
 
     /**
-     * @return \Cake\Datasource\EntityInterface
+     * @return \Cake\Datasource\EntityInterface|array<\Cake\Datasource\EntityInterface>
      */
-    public function getLatestOne(): EntityInterface
+    public function getLatestOne()
     {
-        /**
-         * @var \Cake\Datasource\EntityInterface $entity
-         */
-        $entity = $this->find()->orderDesc('created')->firstOrFail();
-
-        return $entity;
+        return $this->find()->orderDesc('created')->firstOrFail();
     }
 }


### PR DESCRIPTION
PHPStan 1.0 released today and therefore this PR updates the dependency for that.
https://phpstan.org/blog/phpstan-1-0-released

Also I fixed the new errors it threw due to the update.