### PR TITLE
Remove unnecessary left end backslash from the namespace

### DIFF
--- a/src/Type/ComponentLoadDynamicReturnTypeExtension.php
+++ b/src/Type/ComponentLoadDynamicReturnTypeExtension.php
@@ -57,7 +57,7 @@ class ComponentLoadDynamicReturnTypeExtension implements DynamicMethodReturnType
         Scope $scope
     ): Type {
         $defaultClass = Component::class;
-        $namespaceFormat = '\\%s\\Controller\Component\\%sComponent';
+        $namespaceFormat = '%s\\Controller\Component\\%sComponent';
 
         return $this->getRegistryReturnType($methodReflection, $methodCall, $scope, $defaultClass, $namespaceFormat);
     }

--- a/src/Type/ShellHelperLoadDynamicReturnTypeExtension.php
+++ b/src/Type/ShellHelperLoadDynamicReturnTypeExtension.php
@@ -56,7 +56,7 @@ class ShellHelperLoadDynamicReturnTypeExtension implements DynamicMethodReturnTy
         Scope $scope
     ): Type {
         $defaultClass = Helper::class;
-        $namespaceFormat = '\\%s\\Shell\Helper\\%sHelper';
+        $namespaceFormat = '%s\\Shell\Helper\\%sHelper';
 
         return $this->getRegistryReturnType($methodReflection, $methodCall, $scope, $defaultClass, $namespaceFormat);
     }

--- a/src/Type/TableLocatorDynamicReturnTypeExtension.php
+++ b/src/Type/TableLocatorDynamicReturnTypeExtension.php
@@ -58,7 +58,7 @@ class TableLocatorDynamicReturnTypeExtension implements DynamicMethodReturnTypeE
         Scope $scope
     ): Type {
         $defaultClass = Table::class;
-        $namespaceFormat = '\\%s\\Model\\Table\\%sTable';
+        $namespaceFormat = '%s\\Model\\Table\\%sTable';
 
         return $this->getRegistryReturnType($methodReflection, $methodCall, $scope, $defaultClass, $namespaceFormat);
     }


### PR DESCRIPTION
[`PHPStan\Type\ObjectType`](https://github.com/phpstan/phpstan-src/blob/master/src/Type/ObjectType.php) expects a class name that doesn't start with a backslash.

see https://github.com/phpstan/phpstan-src/search?p=2&q=ObjectType