### PR TITLE
Add backslash to function call for performance optimization

### DIFF
--- a/src/Traits/BaseCakeRegistryReturnTrait.php
+++ b/src/Traits/BaseCakeRegistryReturnTrait.php
@@ -42,16 +42,16 @@ trait BaseCakeRegistryReturnTrait
         }
 
         $argType = $scope->getType($methodCall->getArgs()[0]->value);
-        if (!method_exists($argType, 'getValue')) {
+        if (!\method_exists($argType, 'getValue')) {
             return new ObjectType($defaultClass);
         }
         $baseName = $argType->getValue();
         list($plugin, $name) = $this->pluginSplit($baseName);
         $prefixes = $plugin ? [$plugin] : ['Cake', 'App'];
         foreach ($prefixes as $prefix) {
-            $namespace = str_replace('/', '\\', $prefix);
-            $className = sprintf($namespaceFormat, $namespace, $name);
-            if (class_exists($className)) {
+            $namespace = \str_replace('/', '\\', $prefix);
+            $className = \sprintf($namespaceFormat, $namespace, $name);
+            if (\class_exists($className)) {
                 return new ObjectType($className);
             }
         }
@@ -85,6 +85,6 @@ trait BaseCakeRegistryReturnTrait
      */
     protected function pluginSplit($baseName): array
     {
-        return pluginSplit($baseName);
+        return \pluginSplit($baseName);
     }
 }

--- a/src/Type/ShellHelperLoadDynamicReturnTypeExtension.php
+++ b/src/Type/ShellHelperLoadDynamicReturnTypeExtension.php
@@ -69,7 +69,7 @@ class ShellHelperLoadDynamicReturnTypeExtension implements DynamicMethodReturnTy
     protected function pluginSplit($baseName): array
     {
         list($plugin, $name) = pluginSplit($baseName);
-        $name = ucfirst($name);
+        $name = \ucfirst($name);
 
         return [$plugin, $name];
     }


### PR DESCRIPTION
PHP scripts in namespaces look up both functions and global functions in the same namespace, so explicitly stating that they are global functions improves performance. This is a micro-optimization, but it can be effective for frequently called processes such as PHPStan.

You could find a project like [PHP Backslasher](https://github.com/nilportugues/php-backslasher) for this kind of optimization, but this time I've added it manually.