### PR TITLE
Update ConsoleHelperLoadDynamicReturnTypeExtension.php

### DIFF
--- a/src/Type/ConsoleHelperLoadDynamicReturnTypeExtension.php
+++ b/src/Type/ConsoleHelperLoadDynamicReturnTypeExtension.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
 namespace CakeDC\PHPStan\Type;
 
 use Cake\Console\ConsoleIo;
-use Cake\Controller\Component;
+use Cake\Console\Helper;
 use CakeDC\PHPStan\Traits\BaseCakeRegistryReturnTrait;
 use PhpParser\Node\Expr\MethodCall;
 use PHPStan\Analyser\Scope;
@@ -56,7 +56,7 @@ class ConsoleHelperLoadDynamicReturnTypeExtension implements DynamicMethodReturn
         MethodCall $methodCall,
         Scope $scope
     ): Type {
-        $defaultClass = Component::class;
+        $defaultClass = Helper::class;
         $namespaceFormat = '%s\\Command\Helper\\%sHelper';
 
         return $this->getRegistryReturnType($methodReflection, $methodCall, $scope, $defaultClass, $namespaceFormat);


### PR DESCRIPTION
I now get errors in phpstan due to this error:
```
  Line   Console/Io.php                                                                                              
 ------ ------------------------------------------------------------------------------------------------------------ 
  228    Method Queue\Console\Io::helper() should return Cake\Console\Helper but returns Cake\Controller\Component.  
 ------ ------------------------------------------------------------------------------------------------------------ 
```
See https://github.com/dereuromark/cakephp-queue/actions/runs/6260091876/job/16997451316