### PR TITLE
Feature/fetch table with default table

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,4 +70,12 @@ jobs:
 
       - name: Run phpstan
         if: always()
-        run: vendor/bin/phpstan analyse --error-format=github src/
+        run: vendor/bin/phpstan analyse --debug --error-format=github src/
+
+      - name: Run phpstan integration test app
+        if: always()
+        run: vendor/bin/phpstan analyse --debug --error-format=github tests/test_app/
+
+      - name: Run phpstan integration test plugin
+        if: always()
+        run: vendor/bin/phpstan analyse --debug --error-format=github tests/test_plugin/

--- a/composer.json
+++ b/composer.json
@@ -44,10 +44,10 @@
         "cs-fix": "phpcbf -p src/ tests",
         "test": "phpunit --stderr",
         "stan-integration": [
-            "phpstan analyse tests/test_app/",
-            "phpstan analyse tests/test_plugin/"
+            "phpstan analyse --debug tests/test_app/",
+            "phpstan analyse --debug tests/test_plugin/"
         ],
-        "stan": "phpstan analyse src/",
+        "stan": "phpstan analyse --debug src/",
         "check": [
             "@cs-check",
             "@stan",

--- a/extension.neon
+++ b/extension.neon
@@ -10,7 +10,7 @@ services:
 		tags:
 			- phpstan.broker.dynamicMethodReturnTypeExtension
 	-
-		factory: CakeDC\PHPStan\Type\TableLocatorDynamicReturnTypeExtension(Cake\Controller\Controller, fetchTable)
+		factory: CakeDC\PHPStan\Type\ControllerFetchTableDynamicReturnTypeExtension(Cake\Controller\Controller, fetchTable)
 		tags:
 			- phpstan.broker.dynamicMethodReturnTypeExtension
 	-

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -3,4 +3,4 @@ includes:
 
 parameters:
     level: max
-
+    checkGenericClassInNonGenericObjectType: false

--- a/src/Traits/BaseCakeRegistryReturnTrait.php
+++ b/src/Traits/BaseCakeRegistryReturnTrait.php
@@ -32,17 +32,13 @@ trait BaseCakeRegistryReturnTrait
      * @param \PHPStan\Reflection\MethodReflection $methodReflection
      * @param \PhpParser\Node\Expr\MethodCall $methodCall
      * @param \PHPStan\Analyser\Scope $scope
-     * @param string $defaultClass
-     * @param array<string>|string $namespaceFormat
      * @return \PHPStan\Type\Type
      * @throws \PHPStan\ShouldNotHappenException
      */
     protected function getRegistryReturnType(
         MethodReflection $methodReflection,
         MethodCall $methodCall,
-        Scope $scope,
-        string $defaultClass,
-        string|array $namespaceFormat
+        Scope $scope
     ): Type {
         if (count($methodCall->getArgs()) === 0) {
             return ParametersAcceptorSelector::selectSingle($methodReflection->getVariants())
@@ -51,10 +47,10 @@ trait BaseCakeRegistryReturnTrait
 
         $argType = $scope->getType($methodCall->getArgs()[0]->value);
         if (!method_exists($argType, 'getValue')) {
-            return new ObjectType($defaultClass);
+            return new ObjectType($this->defaultClass);
         }
 
-        return $this->getCakeType($argType->getValue(), $defaultClass, $namespaceFormat);
+        return $this->getCakeType($argType->getValue());
     }
 
     /**
@@ -88,15 +84,13 @@ trait BaseCakeRegistryReturnTrait
 
     /**
      * @param string $baseName
-     * @param string $defaultClass
-     * @param array<string>|string $namespaceFormat
      * @return \PHPStan\Type\ObjectType
      */
-    protected function getCakeType(string $baseName, string $defaultClass, array|string $namespaceFormat): ObjectType
+    protected function getCakeType(string $baseName): ObjectType
     {
         [$plugin, $name] = $this->pluginSplit($baseName);
         $prefixes = $plugin ? [$plugin] : ['Cake', 'App'];
-        $namespaceFormat = (array)$namespaceFormat;
+        $namespaceFormat = (array)$this->namespaceFormat;
         foreach ($namespaceFormat as $format) {
             foreach ($prefixes as $prefix) {
                 $namespace = str_replace('/', '\\', $prefix);
@@ -107,6 +101,6 @@ trait BaseCakeRegistryReturnTrait
             }
         }
 
-        return new ObjectType($defaultClass);
+        return new ObjectType($this->defaultClass);
     }
 }

--- a/src/Traits/BaseCakeRegistryReturnTrait.php
+++ b/src/Traits/BaseCakeRegistryReturnTrait.php
@@ -89,7 +89,7 @@ trait BaseCakeRegistryReturnTrait
     /**
      * @param string $baseName
      * @param string $defaultClass
-     * @param array|string $namespaceFormat
+     * @param array<string>|string $namespaceFormat
      * @return \PHPStan\Type\ObjectType
      */
     protected function getCakeType(string $baseName, string $defaultClass, array|string $namespaceFormat): ObjectType

--- a/src/Traits/BaseCakeRegistryReturnTrait.php
+++ b/src/Traits/BaseCakeRegistryReturnTrait.php
@@ -35,11 +35,11 @@ trait BaseCakeRegistryReturnTrait
      * @return \PHPStan\Type\Type
      * @throws \PHPStan\ShouldNotHappenException
      */
-    protected function getRegistryReturnType(
+    public function getTypeFromMethodCall(
         MethodReflection $methodReflection,
         MethodCall $methodCall,
         Scope $scope
-    ): Type {
+    ): ?Type {
         if (count($methodCall->getArgs()) === 0) {
             return ParametersAcceptorSelector::selectSingle($methodReflection->getVariants())
                 ->getReturnType();

--- a/src/Traits/BaseCakeRegistryReturnTrait.php
+++ b/src/Traits/BaseCakeRegistryReturnTrait.php
@@ -39,7 +39,7 @@ trait BaseCakeRegistryReturnTrait
         MethodReflection $methodReflection,
         MethodCall $methodCall,
         Scope $scope
-    ): ?Type {
+    ): Type {
         if (count($methodCall->getArgs()) === 0) {
             return ParametersAcceptorSelector::selectSingle($methodReflection->getVariants())
                 ->getReturnType();

--- a/src/Traits/BaseCakeRegistryReturnTrait.php
+++ b/src/Traits/BaseCakeRegistryReturnTrait.php
@@ -53,21 +53,8 @@ trait BaseCakeRegistryReturnTrait
         if (!method_exists($argType, 'getValue')) {
             return new ObjectType($defaultClass);
         }
-        $baseName = $argType->getValue();
-        [$plugin, $name] = $this->pluginSplit($baseName);
-        $prefixes = $plugin ? [$plugin] : ['Cake', 'App'];
-        $namespaceFormat = (array)$namespaceFormat;
-        foreach ($namespaceFormat as $format) {
-            foreach ($prefixes as $prefix) {
-                $namespace = str_replace('/', '\\', $prefix);
-                $className = sprintf($format, $namespace, $name);
-                if (class_exists($className)) {
-                    return new ObjectType($className);
-                }
-            }
-        }
 
-        return new ObjectType($defaultClass);
+        return $this->getCakeType($argType->getValue(), $defaultClass, $namespaceFormat);
     }
 
     /**
@@ -97,5 +84,29 @@ trait BaseCakeRegistryReturnTrait
     protected function pluginSplit(string $baseName): array
     {
         return pluginSplit($baseName);
+    }
+
+    /**
+     * @param string $baseName
+     * @param string $defaultClass
+     * @param array|string $namespaceFormat
+     * @return \PHPStan\Type\ObjectType
+     */
+    protected function getCakeType(string $baseName, string $defaultClass, array|string $namespaceFormat): ObjectType
+    {
+        [$plugin, $name] = $this->pluginSplit($baseName);
+        $prefixes = $plugin ? [$plugin] : ['Cake', 'App'];
+        $namespaceFormat = (array)$namespaceFormat;
+        foreach ($namespaceFormat as $format) {
+            foreach ($prefixes as $prefix) {
+                $namespace = str_replace('/', '\\', $prefix);
+                $className = sprintf($format, $namespace, $name);
+                if (class_exists($className)) {
+                    return new ObjectType($className);
+                }
+            }
+        }
+
+        return new ObjectType($defaultClass);
     }
 }

--- a/src/Traits/BaseCakeRegistryReturnTrait.php
+++ b/src/Traits/BaseCakeRegistryReturnTrait.php
@@ -41,8 +41,7 @@ trait BaseCakeRegistryReturnTrait
         Scope $scope
     ): Type {
         if (count($methodCall->getArgs()) === 0) {
-            return ParametersAcceptorSelector::selectSingle($methodReflection->getVariants())
-                ->getReturnType();
+            return $this->getTypeWhenNotFound($methodReflection);
         }
 
         $argType = $scope->getType($methodCall->getArgs()[0]->value);
@@ -102,5 +101,16 @@ trait BaseCakeRegistryReturnTrait
         }
 
         return new ObjectType($this->defaultClass);
+    }
+
+    /**
+     * @param \PHPStan\Reflection\MethodReflection $methodReflection
+     * @return \PHPStan\Type\Type
+     * @throws \PHPStan\ShouldNotHappenException
+     */
+    protected function getTypeWhenNotFound(MethodReflection $methodReflection): Type
+    {
+        return ParametersAcceptorSelector::selectSingle($methodReflection->getVariants())
+            ->getReturnType();
     }
 }

--- a/src/Type/ComponentLoadDynamicReturnTypeExtension.php
+++ b/src/Type/ComponentLoadDynamicReturnTypeExtension.php
@@ -16,11 +16,7 @@ namespace CakeDC\PHPStan\Type;
 use Cake\Controller\Component;
 use Cake\Controller\Controller;
 use CakeDC\PHPStan\Traits\BaseCakeRegistryReturnTrait;
-use PhpParser\Node\Expr\MethodCall;
-use PHPStan\Analyser\Scope;
-use PHPStan\Reflection\MethodReflection;
 use PHPStan\Type\DynamicMethodReturnTypeExtension;
-use PHPStan\Type\Type;
 
 class ComponentLoadDynamicReturnTypeExtension implements DynamicMethodReturnTypeExtension
 {

--- a/src/Type/ComponentLoadDynamicReturnTypeExtension.php
+++ b/src/Type/ComponentLoadDynamicReturnTypeExtension.php
@@ -36,18 +36,29 @@ class ComponentLoadDynamicReturnTypeExtension implements DynamicMethodReturnType
     private string $methodName;
 
     /**
+     * @var string
+     */
+    protected string $defaultClass;
+    /**
+     * @var string
+     */
+    protected string $namespaceFormat;
+
+    /**
      * TableLocatorDynamicReturnTypeExtension constructor.
      */
     public function __construct()
     {
         $this->className = Controller::class;
         $this->methodName = 'loadComponent';
+        $this->defaultClass = Component::class;
+        $this->namespaceFormat = '%s\\Controller\Component\\%sComponent';
     }
 
     /**
      * @param \PHPStan\Reflection\MethodReflection $methodReflection
-     * @param \PhpParser\Node\Expr\MethodCall       $methodCall
-     * @param \PHPStan\Analyser\Scope            $scope
+     * @param \PhpParser\Node\Expr\MethodCall $methodCall
+     * @param \PHPStan\Analyser\Scope $scope
      * @return \PHPStan\Type\Type
      * @throws \PHPStan\ShouldNotHappenException
      */
@@ -56,9 +67,7 @@ class ComponentLoadDynamicReturnTypeExtension implements DynamicMethodReturnType
         MethodCall $methodCall,
         Scope $scope
     ): Type {
-        $defaultClass = Component::class;
-        $namespaceFormat = '%s\\Controller\Component\\%sComponent';
 
-        return $this->getRegistryReturnType($methodReflection, $methodCall, $scope, $defaultClass, $namespaceFormat);
+        return $this->getRegistryReturnType($methodReflection, $methodCall, $scope);
     }
 }

--- a/src/Type/ComponentLoadDynamicReturnTypeExtension.php
+++ b/src/Type/ComponentLoadDynamicReturnTypeExtension.php
@@ -54,20 +54,4 @@ class ComponentLoadDynamicReturnTypeExtension implements DynamicMethodReturnType
         $this->defaultClass = Component::class;
         $this->namespaceFormat = '%s\\Controller\Component\\%sComponent';
     }
-
-    /**
-     * @param \PHPStan\Reflection\MethodReflection $methodReflection
-     * @param \PhpParser\Node\Expr\MethodCall $methodCall
-     * @param \PHPStan\Analyser\Scope $scope
-     * @return \PHPStan\Type\Type
-     * @throws \PHPStan\ShouldNotHappenException
-     */
-    public function getTypeFromMethodCall(
-        MethodReflection $methodReflection,
-        MethodCall $methodCall,
-        Scope $scope
-    ): Type {
-
-        return $this->getRegistryReturnType($methodReflection, $methodCall, $scope);
-    }
 }

--- a/src/Type/ConsoleHelperLoadDynamicReturnTypeExtension.php
+++ b/src/Type/ConsoleHelperLoadDynamicReturnTypeExtension.php
@@ -16,11 +16,7 @@ namespace CakeDC\PHPStan\Type;
 use Cake\Console\ConsoleIo;
 use Cake\Console\Helper;
 use CakeDC\PHPStan\Traits\BaseCakeRegistryReturnTrait;
-use PhpParser\Node\Expr\MethodCall;
-use PHPStan\Analyser\Scope;
-use PHPStan\Reflection\MethodReflection;
 use PHPStan\Type\DynamicMethodReturnTypeExtension;
-use PHPStan\Type\ObjectType;
 use PHPStan\Type\Type;
 
 class ConsoleHelperLoadDynamicReturnTypeExtension implements DynamicMethodReturnTypeExtension
@@ -58,29 +54,13 @@ class ConsoleHelperLoadDynamicReturnTypeExtension implements DynamicMethodReturn
     }
 
     /**
-     * @param \PHPStan\Reflection\MethodReflection $methodReflection
-     * @param \PhpParser\Node\Expr\MethodCall $methodCall
-     * @param \PHPStan\Analyser\Scope $scope
-     * @return \PHPStan\Type\Type
-     * @throws \PHPStan\ShouldNotHappenException
-     */
-    public function getTypeFromMethodCall(
-        MethodReflection $methodReflection,
-        MethodCall $methodCall,
-        Scope $scope
-    ): Type {
-
-        return $this->getRegistryReturnType($methodReflection, $methodCall, $scope);
-    }
-
-    /**
      * Before calling BaseCakeRegistryReturnTrait::getCakeType uppercase the
      * first letter as done in the method ConsoleIo::helper
      *
      * @param string $baseName
      * @return \PHPStan\Type\ObjectType
      */
-    protected function getCakeType(string $baseName): ObjectType
+    protected function getCakeType(string $baseName): Type
     {
         $baseName = ucfirst($baseName);
 

--- a/src/Type/ConsoleHelperLoadDynamicReturnTypeExtension.php
+++ b/src/Type/ConsoleHelperLoadDynamicReturnTypeExtension.php
@@ -20,11 +20,14 @@ use PhpParser\Node\Expr\MethodCall;
 use PHPStan\Analyser\Scope;
 use PHPStan\Reflection\MethodReflection;
 use PHPStan\Type\DynamicMethodReturnTypeExtension;
+use PHPStan\Type\ObjectType;
 use PHPStan\Type\Type;
 
 class ConsoleHelperLoadDynamicReturnTypeExtension implements DynamicMethodReturnTypeExtension
 {
-    use BaseCakeRegistryReturnTrait;
+    use BaseCakeRegistryReturnTrait {
+        getCakeType as _getCakeType;
+    }
 
     /**
      * @var string
@@ -60,5 +63,21 @@ class ConsoleHelperLoadDynamicReturnTypeExtension implements DynamicMethodReturn
         $namespaceFormat = '%s\\Command\Helper\\%sHelper';
 
         return $this->getRegistryReturnType($methodReflection, $methodCall, $scope, $defaultClass, $namespaceFormat);
+    }
+
+    /**
+     * Before calling BaseCakeRegistryReturnTrait::getCakeType uppercase the
+     * first letter as done in the method ConsoleIo::helper
+     *
+     * @param string $baseName
+     * @param string $defaultClass
+     * @param array<string>|string $namespaceFormat
+     * @return \PHPStan\Type\ObjectType
+     */
+    protected function getCakeType(string $baseName, string $defaultClass, array|string $namespaceFormat): ObjectType
+    {
+        $baseName = ucfirst($baseName);
+
+        return $this->_getCakeType($baseName, $defaultClass, $namespaceFormat);
     }
 }

--- a/src/Type/ConsoleHelperLoadDynamicReturnTypeExtension.php
+++ b/src/Type/ConsoleHelperLoadDynamicReturnTypeExtension.php
@@ -37,6 +37,14 @@ class ConsoleHelperLoadDynamicReturnTypeExtension implements DynamicMethodReturn
      * @var string
      */
     private string $methodName;
+    /**
+     * @var string
+     */
+    protected string $defaultClass;
+    /**
+     * @var string
+     */
+    protected string $namespaceFormat;
 
     /**
      * TableLocatorDynamicReturnTypeExtension constructor.
@@ -45,12 +53,14 @@ class ConsoleHelperLoadDynamicReturnTypeExtension implements DynamicMethodReturn
     {
         $this->className = ConsoleIo::class;
         $this->methodName = 'helper';
+        $this->defaultClass = Helper::class;
+        $this->namespaceFormat = '%s\\Command\Helper\\%sHelper';
     }
 
     /**
      * @param \PHPStan\Reflection\MethodReflection $methodReflection
-     * @param \PhpParser\Node\Expr\MethodCall       $methodCall
-     * @param \PHPStan\Analyser\Scope            $scope
+     * @param \PhpParser\Node\Expr\MethodCall $methodCall
+     * @param \PHPStan\Analyser\Scope $scope
      * @return \PHPStan\Type\Type
      * @throws \PHPStan\ShouldNotHappenException
      */
@@ -59,10 +69,8 @@ class ConsoleHelperLoadDynamicReturnTypeExtension implements DynamicMethodReturn
         MethodCall $methodCall,
         Scope $scope
     ): Type {
-        $defaultClass = Helper::class;
-        $namespaceFormat = '%s\\Command\Helper\\%sHelper';
 
-        return $this->getRegistryReturnType($methodReflection, $methodCall, $scope, $defaultClass, $namespaceFormat);
+        return $this->getRegistryReturnType($methodReflection, $methodCall, $scope);
     }
 
     /**
@@ -70,14 +78,12 @@ class ConsoleHelperLoadDynamicReturnTypeExtension implements DynamicMethodReturn
      * first letter as done in the method ConsoleIo::helper
      *
      * @param string $baseName
-     * @param string $defaultClass
-     * @param array<string>|string $namespaceFormat
      * @return \PHPStan\Type\ObjectType
      */
-    protected function getCakeType(string $baseName, string $defaultClass, array|string $namespaceFormat): ObjectType
+    protected function getCakeType(string $baseName): ObjectType
     {
         $baseName = ucfirst($baseName);
 
-        return $this->_getCakeType($baseName, $defaultClass, $namespaceFormat);
+        return $this->_getCakeType($baseName);
     }
 }

--- a/src/Type/ControllerFetchTableDynamicReturnTypeExtension.php
+++ b/src/Type/ControllerFetchTableDynamicReturnTypeExtension.php
@@ -1,6 +1,16 @@
 <?php
 declare(strict_types=1);
 
+/**
+ * Copyright 2023, Cake Development Corporation (https://www.cakedc.com)
+ *
+ * Licensed under The MIT License
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright Copyright 2023, Cake Development Corporation (https://www.cakedc.com)
+ * @license   MIT License (http://www.opensource.org/licenses/mit-license.php)
+ */
+
 namespace CakeDC\PHPStan\Type;
 
 use PHPStan\Analyser\Scope;

--- a/src/Type/ControllerFetchTableDynamicReturnTypeExtension.php
+++ b/src/Type/ControllerFetchTableDynamicReturnTypeExtension.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace CakeDC\PHPStan\Type;
+
+use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\MethodReflection;
+use PHPStan\Reflection\ParametersAcceptorSelector;
+use PHPStan\Type\ObjectType;
+use PHPStan\Type\Type;
+
+class ControllerFetchTableDynamicReturnTypeExtension extends TableLocatorDynamicReturnTypeExtension
+{
+    /**
+     * @inheritDoc
+     */
+    protected function getReturnTypeWithoutArgs(Scope $scope, string $defaultClass, string $namespaceFormat, MethodReflection $methodReflection): \PHPStan\Type\ObjectType|Type
+    {
+
+        try {
+            $defaultTable = $this->getDefaultTable($scope);
+            if (is_string($defaultTable) && $defaultTable) {
+                return $this->getCakeType($defaultTable, $defaultClass, $namespaceFormat);
+            }
+        } catch (\ReflectionException) {
+        }
+        $tableClassName = $this->getDefaultTableByControllerClass($scope);
+        if ($tableClassName !== null) {
+            return new ObjectType($tableClassName);
+        }
+
+        return ParametersAcceptorSelector::selectSingle($methodReflection->getVariants())
+            ->getReturnType();
+
+    }
+
+    /**
+     * @param \PHPStan\Analyser\Scope $scope
+     * @return string|null
+     */
+    protected function getDefaultTableByControllerClass(Scope $scope): ?string
+    {
+        $hasProperty = $scope->getClassReflection()
+            ?->getNativeReflection()
+            ?->hasProperty('defaultTable');
+        if (!$hasProperty) {
+            return null;
+        }
+        $namespace = $scope->getClassReflection()
+            ->getNativeReflection()
+            ->getNamespaceName();
+        $pos = strrpos($namespace, '\\Controller');
+        if ($pos === false) {
+            return null;
+        }
+        $baseNamespace = substr($namespace, 0, $pos);
+        $shortName = $scope->getClassReflection()
+            ->getNativeReflection()
+            ->getShortName();
+        $shortName = str_replace('Controller', '', $shortName);
+        $tableClassName = sprintf('%s\\Model\\Table\\%sTable',
+            $baseNamespace,
+            $shortName
+        );
+
+        if (class_exists($tableClassName)) {
+            return $tableClassName;
+        }
+
+        return null;
+    }
+
+}

--- a/src/Type/ControllerFetchTableDynamicReturnTypeExtension.php
+++ b/src/Type/ControllerFetchTableDynamicReturnTypeExtension.php
@@ -17,6 +17,7 @@ use PhpParser\Node\Expr\MethodCall;
 use PHPStan\Reflection\MethodReflection;
 use PHPStan\Type\ObjectType;
 use PHPStan\Type\Type;
+use ReflectionClass;
 
 class ControllerFetchTableDynamicReturnTypeExtension extends TableLocatorDynamicReturnTypeExtension
 {
@@ -26,7 +27,7 @@ class ControllerFetchTableDynamicReturnTypeExtension extends TableLocatorDynamic
     protected function getReturnTypeWithoutArgs(
         MethodReflection $methodReflection,
         MethodCall $methodCall,
-        \ReflectionClass $targetClassReflection
+        ReflectionClass $targetClassReflection
     ): ?Type {
         $type = parent::getReturnTypeWithoutArgs($methodReflection, $methodCall, $targetClassReflection);
         if ($type !== null) {
@@ -44,7 +45,7 @@ class ControllerFetchTableDynamicReturnTypeExtension extends TableLocatorDynamic
      * @param \ReflectionClass $targetClassReflection
      * @return string|null
      */
-    protected function getDefaultTableByControllerClass(\ReflectionClass $targetClassReflection): ?string
+    protected function getDefaultTableByControllerClass(ReflectionClass $targetClassReflection): ?string
     {
         $hasProperty = $targetClassReflection->hasProperty('defaultTable');
         if (!$hasProperty) {

--- a/src/Type/ControllerFetchTableDynamicReturnTypeExtension.php
+++ b/src/Type/ControllerFetchTableDynamicReturnTypeExtension.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace CakeDC\PHPStan\Type;
 
@@ -7,21 +8,25 @@ use PHPStan\Reflection\MethodReflection;
 use PHPStan\Reflection\ParametersAcceptorSelector;
 use PHPStan\Type\ObjectType;
 use PHPStan\Type\Type;
+use ReflectionException;
 
 class ControllerFetchTableDynamicReturnTypeExtension extends TableLocatorDynamicReturnTypeExtension
 {
     /**
      * @inheritDoc
      */
-    protected function getReturnTypeWithoutArgs(Scope $scope, string $defaultClass, string $namespaceFormat, MethodReflection $methodReflection): \PHPStan\Type\ObjectType|Type
-    {
-
+    protected function getReturnTypeWithoutArgs(
+        Scope $scope,
+        string $defaultClass,
+        string $namespaceFormat,
+        MethodReflection $methodReflection
+    ): ObjectType|Type {
         try {
             $defaultTable = $this->getDefaultTable($scope);
             if (is_string($defaultTable) && $defaultTable) {
                 return $this->getCakeType($defaultTable, $defaultClass, $namespaceFormat);
             }
-        } catch (\ReflectionException) {
+        } catch (ReflectionException) {
         }
         $tableClassName = $this->getDefaultTableByControllerClass($scope);
         if ($tableClassName !== null) {
@@ -30,7 +35,6 @@ class ControllerFetchTableDynamicReturnTypeExtension extends TableLocatorDynamic
 
         return ParametersAcceptorSelector::selectSingle($methodReflection->getVariants())
             ->getReturnType();
-
     }
 
     /**
@@ -45,19 +49,20 @@ class ControllerFetchTableDynamicReturnTypeExtension extends TableLocatorDynamic
         if (!$hasProperty) {
             return null;
         }
-        $namespace = $scope->getClassReflection()
-            ->getNativeReflection()
-            ->getNamespaceName();
+        $namespace = (string)$scope->getClassReflection()
+            ?->getNativeReflection()
+            ?->getNamespaceName();
         $pos = strrpos($namespace, '\\Controller');
         if ($pos === false) {
             return null;
         }
         $baseNamespace = substr($namespace, 0, $pos);
-        $shortName = $scope->getClassReflection()
-            ->getNativeReflection()
-            ->getShortName();
+        $shortName = (string)$scope->getClassReflection()
+            ?->getNativeReflection()
+            ?->getShortName();
         $shortName = str_replace('Controller', '', $shortName);
-        $tableClassName = sprintf('%s\\Model\\Table\\%sTable',
+        $tableClassName = sprintf(
+            '%s\\Model\\Table\\%sTable',
             $baseNamespace,
             $shortName
         );
@@ -68,5 +73,4 @@ class ControllerFetchTableDynamicReturnTypeExtension extends TableLocatorDynamic
 
         return null;
     }
-
 }

--- a/src/Type/ControllerFetchTableDynamicReturnTypeExtension.php
+++ b/src/Type/ControllerFetchTableDynamicReturnTypeExtension.php
@@ -27,7 +27,7 @@ class ControllerFetchTableDynamicReturnTypeExtension extends TableLocatorDynamic
         MethodReflection $methodReflection,
         MethodCall $methodCall,
         \ReflectionClass $targetClassReflection
-    ): ObjectType|Type|null {
+    ): ?Type {
         $type = parent::getReturnTypeWithoutArgs($methodReflection, $methodCall, $targetClassReflection);
         if ($type !== null) {
             return $type;

--- a/src/Type/TableLocatorDynamicReturnTypeExtension.php
+++ b/src/Type/TableLocatorDynamicReturnTypeExtension.php
@@ -20,6 +20,7 @@ use PHPStan\Analyser\Scope;
 use PHPStan\Reflection\MethodReflection;
 use PHPStan\Reflection\ParametersAcceptorSelector;
 use PHPStan\Type\DynamicMethodReturnTypeExtension;
+use PHPStan\Type\ObjectType;
 use PHPStan\Type\Type;
 use ReflectionException;
 
@@ -81,6 +82,7 @@ class TableLocatorDynamicReturnTypeExtension implements DynamicMethodReturnTypeE
             ?->getNativeReflection()
             ?->getProperty('defaultTable')
             ?->getDefaultValue();
+
         return $defaultTable;
     }
 
@@ -92,8 +94,12 @@ class TableLocatorDynamicReturnTypeExtension implements DynamicMethodReturnTypeE
      * @return \PHPStan\Type\ObjectType|\PHPStan\Type\Type
      * @throws \PHPStan\ShouldNotHappenException
      */
-    protected function getReturnTypeWithoutArgs(Scope $scope, string $defaultClass, string $namespaceFormat, MethodReflection $methodReflection): \PHPStan\Type\ObjectType|Type
-    {
+    protected function getReturnTypeWithoutArgs(
+        Scope $scope,
+        string $defaultClass,
+        string $namespaceFormat,
+        MethodReflection $methodReflection
+    ): ObjectType|Type {
         try {
             $defaultTable = $this->getDefaultTable($scope);
             if (is_string($defaultTable) && $defaultTable) {

--- a/src/Type/TableLocatorDynamicReturnTypeExtension.php
+++ b/src/Type/TableLocatorDynamicReturnTypeExtension.php
@@ -19,13 +19,14 @@ use PhpParser\Node\Expr\MethodCall;
 use PHPStan\Analyser\Scope;
 use PHPStan\Reflection\MethodReflection;
 use PHPStan\Type\DynamicMethodReturnTypeExtension;
-use PHPStan\Type\ObjectType;
 use PHPStan\Type\Type;
 use ReflectionException;
 
 class TableLocatorDynamicReturnTypeExtension implements DynamicMethodReturnTypeExtension
 {
-    use BaseCakeRegistryReturnTrait;
+    use BaseCakeRegistryReturnTrait {
+        getTypeFromMethodCall as getTypeFromMethodCallWithArgs;
+    }
 
     /**
      * @var string
@@ -73,7 +74,7 @@ class TableLocatorDynamicReturnTypeExtension implements DynamicMethodReturnTypeE
             return $this->getReturnTypeWithoutArgs($methodReflection, $methodCall, $targetClassReflection);
         }
 
-        return $this->getRegistryReturnType($methodReflection, $methodCall, $scope);
+        return $this->getTypeFromMethodCallWithArgs($methodReflection, $methodCall, $scope);
     }
 
     /**
@@ -90,14 +91,13 @@ class TableLocatorDynamicReturnTypeExtension implements DynamicMethodReturnTypeE
      * @param \PHPStan\Reflection\MethodReflection $methodReflection
      * @param \PhpParser\Node\Expr\MethodCall $methodCall
      * @param \ReflectionClass $targetClassReflection
-     * @return \PHPStan\Type\ObjectType|\PHPStan\Type\Type
-     * @throws \PHPStan\ShouldNotHappenException
+     * @return \PHPStan\Type\Type|null
      */
     protected function getReturnTypeWithoutArgs(
         MethodReflection $methodReflection,
         MethodCall $methodCall,
         \ReflectionClass $targetClassReflection
-    ): ObjectType|Type|null {
+    ): Type|null {
         try {
             $defaultTable = $this->getDefaultTable($targetClassReflection);
             if (is_string($defaultTable) && $defaultTable) {

--- a/src/Type/TableLocatorDynamicReturnTypeExtension.php
+++ b/src/Type/TableLocatorDynamicReturnTypeExtension.php
@@ -69,7 +69,7 @@ class TableLocatorDynamicReturnTypeExtension implements DynamicMethodReturnTypeE
                     ?->getNativeReflection()
                     ?->getProperty('defaultTable')
                     ?->getDefaultValue();
-                if ($defaultTable) {
+                if (is_string($defaultTable) && $defaultTable) {
                     return $this->getCakeType($defaultTable, $defaultClass, $namespaceFormat);
                 }
             } catch (ReflectionException) {

--- a/src/Type/TableLocatorDynamicReturnTypeExtension.php
+++ b/src/Type/TableLocatorDynamicReturnTypeExtension.php
@@ -65,14 +65,18 @@ class TableLocatorDynamicReturnTypeExtension implements DynamicMethodReturnTypeE
         MethodReflection $methodReflection,
         MethodCall $methodCall,
         Scope $scope
-    ): ?Type {
+    ): Type {
         if (count($methodCall->getArgs()) === 0) {
             $targetClassReflection = $this->getTargetClassReflection($scope, $methodCall);
-            if ($targetClassReflection === null) {
-                return null;
+            $type = null;
+            if ($targetClassReflection !== null) {
+                $type = $this->getReturnTypeWithoutArgs($methodReflection, $methodCall, $targetClassReflection);
+            }
+            if ($type !== null) {
+                return $type;
             }
 
-            return $this->getReturnTypeWithoutArgs($methodReflection, $methodCall, $targetClassReflection);
+            return $this->getTypeWhenNotFound($methodReflection);
         }
 
         return $this->getTypeFromMethodCallWithArgs($methodReflection, $methodCall, $scope);

--- a/src/Type/TableLocatorDynamicReturnTypeExtension.php
+++ b/src/Type/TableLocatorDynamicReturnTypeExtension.php
@@ -64,9 +64,6 @@ class TableLocatorDynamicReturnTypeExtension implements DynamicMethodReturnTypeE
         MethodCall $methodCall,
         Scope $scope
     ): ?Type {
-        $defaultClass = Table::class;
-        $namespaceFormat = '%s\\Model\\Table\\%sTable';
-
         if (count($methodCall->getArgs()) === 0) {
             $targetClassReflection = $this->getTargetClassReflection($scope, $methodCall);
             if ($targetClassReflection === null) {
@@ -76,7 +73,7 @@ class TableLocatorDynamicReturnTypeExtension implements DynamicMethodReturnTypeE
             return $this->getReturnTypeWithoutArgs($methodReflection, $methodCall, $targetClassReflection);
         }
 
-        return $this->getRegistryReturnType($methodReflection, $methodCall, $scope, $defaultClass, $namespaceFormat);
+        return $this->getRegistryReturnType($methodReflection, $methodCall, $scope);
     }
 
     /**
@@ -104,7 +101,7 @@ class TableLocatorDynamicReturnTypeExtension implements DynamicMethodReturnTypeE
         try {
             $defaultTable = $this->getDefaultTable($targetClassReflection);
             if (is_string($defaultTable) && $defaultTable) {
-                return $this->getCakeType($defaultTable, $this->defaultClass, $this->namespaceFormat);
+                return $this->getCakeType($defaultTable);
             }
         } catch (ReflectionException) {
         }

--- a/tests/test_app/Controller/Component/WarningComponent.php
+++ b/tests/test_app/Controller/Component/WarningComponent.php
@@ -1,4 +1,15 @@
 <?php
+declare(strict_types=1);
+
+/**
+ * Copyright 2023, Cake Development Corporation (https://www.cakedc.com)
+ *
+ * Licensed under The MIT License
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright Copyright 2020, Cake Development Corporation (https://www.cakedc.com)
+ * @license   MIT License (http://www.opensource.org/licenses/mit-license.php)
+ */
 
 namespace App\Controller\Component;
 

--- a/tests/test_app/Controller/Component/WarningComponent.php
+++ b/tests/test_app/Controller/Component/WarningComponent.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Controller\Component;
+
+use Cake\Controller\Component;
+
+class WarningComponent extends Component
+{
+    /**
+     * @return void
+     */
+    public function testWarning()
+    {
+        /**
+         * @var \App\Controller\NotesController $controller
+         */
+        $controller = $this->getController();
+        $controller->fetchTable()->warning();
+    }
+}

--- a/tests/test_app/Controller/MyTestLoadComponentController.php
+++ b/tests/test_app/Controller/MyTestLoadComponentController.php
@@ -50,6 +50,7 @@ class MyTestLoadComponentController extends Controller
     /**
      * Test TableLocatorDynamicReturnTypeExtension with fetchTable using source $defaultTable
      * for this case is 'VeryCustomize00009Articles'
+     *
      * @return void
      */
     public function myTestWithDefaultTable()

--- a/tests/test_app/Controller/MyTestLoadComponentController.php
+++ b/tests/test_app/Controller/MyTestLoadComponentController.php
@@ -18,6 +18,13 @@ use Cake\Controller\Controller;
 class MyTestLoadComponentController extends Controller
 {
     /**
+     * This object's default table alias.
+     *
+     * @var string|null
+     */
+    protected ?string $defaultTable = 'VeryCustomize00009Articles';
+
+    /**
      * Testing ComponentLoadDynamicReturnTypeExtension
      *
      * @return void
@@ -28,7 +35,7 @@ class MyTestLoadComponentController extends Controller
     }
 
     /**
-     * Test TableLocatorDynamicReturnTypeExtension with load model
+     * Test TableLocatorDynamicReturnTypeExtension with fetchTable
      *
      * @return void
      */
@@ -38,5 +45,16 @@ class MyTestLoadComponentController extends Controller
         $latest = $this->fetchTable('CakeDC/MyPlugin.HelloWorld101010Articles')
             ->getLatestOne();
         $this->set('latest', $latest);
+    }
+
+    /**
+     * Test TableLocatorDynamicReturnTypeExtension with fetchTable using source $defaultTable
+     * for this case is 'VeryCustomize00009Articles'
+     * @return void
+     */
+    public function myTestWithDefaultTable()
+    {
+        $sample = $this->fetchTable()->newSample();
+        $this->set(compact('sample'));
     }
 }

--- a/tests/test_app/Controller/NotesController.php
+++ b/tests/test_app/Controller/NotesController.php
@@ -17,7 +17,6 @@ use Cake\Controller\Controller;
 
 class NotesController extends Controller
 {
-
     /**
      * Test ControllerFetchTableDynamicReturnTypeExtension with fetchTable using controller's className to extract
      * correct table class

--- a/tests/test_app/Controller/NotesController.php
+++ b/tests/test_app/Controller/NotesController.php
@@ -1,0 +1,32 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * Copyright 2020, Cake Development Corporation (https://www.cakedc.com)
+ *
+ * Licensed under The MIT License
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright Copyright 2020, Cake Development Corporation (https://www.cakedc.com)
+ * @license   MIT License (http://www.opensource.org/licenses/mit-license.php)
+ */
+
+namespace App\Controller;
+
+use Cake\Controller\Controller;
+
+class NotesController extends Controller
+{
+
+    /**
+     * Test ControllerFetchTableDynamicReturnTypeExtension with fetchTable using controller's className to extract
+     * correct table class
+     *
+     * @return void
+     */
+    public function addWarning()
+    {
+        $data = $this->fetchTable()->warning();
+        $this->set(compact('data'));
+    }
+}

--- a/tests/test_app/Controller/NotesController.php
+++ b/tests/test_app/Controller/NotesController.php
@@ -2,12 +2,12 @@
 declare(strict_types=1);
 
 /**
- * Copyright 2020, Cake Development Corporation (https://www.cakedc.com)
+ * Copyright 2023, Cake Development Corporation (https://www.cakedc.com)
  *
  * Licensed under The MIT License
  * Redistributions of files must retain the above copyright notice.
  *
- * @copyright Copyright 2020, Cake Development Corporation (https://www.cakedc.com)
+ * @copyright Copyright 2023, Cake Development Corporation (https://www.cakedc.com)
  * @license   MIT License (http://www.opensource.org/licenses/mit-license.php)
  */
 

--- a/tests/test_app/Model/Table/NotesTable.php
+++ b/tests/test_app/Model/Table/NotesTable.php
@@ -1,0 +1,27 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * Copyright 2023, Cake Development Corporation (https://www.cakedc.com)
+ *
+ * Licensed under The MIT License
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright Copyright 2023, Cake Development Corporation (https://www.cakedc.com)
+ * @license   MIT License (http://www.opensource.org/licenses/mit-license.php)
+ */
+
+namespace App\Model\Table;
+
+use Cake\ORM\Table;
+
+class NotesTable extends Table
+{
+    /**
+     * @return string[]
+     */
+    public function warning(): array
+    {
+        return ['note' => 'warning'];
+    }
+}

--- a/tests/test_plugin/Controller/Admin/NotesController.php
+++ b/tests/test_plugin/Controller/Admin/NotesController.php
@@ -1,0 +1,32 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * Copyright 2023, Cake Development Corporation (https://www.cakedc.com)
+ *
+ * Licensed under The MIT License
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright Copyright 2023, Cake Development Corporation (https://www.cakedc.com)
+ * @license   MIT License (http://www.opensource.org/licenses/mit-license.php)
+ */
+
+namespace CakeDC\MyPlugin\Controller\Admin;
+
+use Cake\Controller\Controller;
+
+class NotesController extends Controller
+{
+
+    /**
+     * Test ControllerFetchTableDynamicReturnTypeExtension with fetchTable using controller's className (with prefix) to extract
+     * correct table class
+     *
+     * @return void
+     */
+    public function addNotice()
+    {
+        $data = $this->fetchTable()->notice();
+        $this->set(compact('data'));
+    }
+}

--- a/tests/test_plugin/Controller/Admin/NotesController.php
+++ b/tests/test_plugin/Controller/Admin/NotesController.php
@@ -17,7 +17,6 @@ use Cake\Controller\Controller;
 
 class NotesController extends Controller
 {
-
     /**
      * Test ControllerFetchTableDynamicReturnTypeExtension with fetchTable using controller's className (with prefix) to extract
      * correct table class

--- a/tests/test_plugin/Controller/Manager/NotesController.php
+++ b/tests/test_plugin/Controller/Manager/NotesController.php
@@ -1,0 +1,32 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * Copyright 2023, Cake Development Corporation (https://www.cakedc.com)
+ *
+ * Licensed under The MIT License
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright Copyright 2023, Cake Development Corporation (https://www.cakedc.com)
+ * @license   MIT License (http://www.opensource.org/licenses/mit-license.php)
+ */
+
+namespace CakeDC\MyPlugin\Controller\Manager;
+
+use Cake\Controller\Controller;
+
+class NotesController extends Controller
+{
+
+    /**
+     * Test ControllerFetchTableDynamicReturnTypeExtension with fetchTable using controller's className (with prefix) to extract
+     * correct table class
+     *
+     * @return void
+     */
+    public function addInfo()
+    {
+        $data = $this->fetchTable()->info();
+        $this->set(compact('data'));
+    }
+}

--- a/tests/test_plugin/Controller/Manager/NotesController.php
+++ b/tests/test_plugin/Controller/Manager/NotesController.php
@@ -17,7 +17,6 @@ use Cake\Controller\Controller;
 
 class NotesController extends Controller
 {
-
     /**
      * Test ControllerFetchTableDynamicReturnTypeExtension with fetchTable using controller's className (with prefix) to extract
      * correct table class

--- a/tests/test_plugin/Controller/NotesController.php
+++ b/tests/test_plugin/Controller/NotesController.php
@@ -1,0 +1,32 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * Copyright 2020, Cake Development Corporation (https://www.cakedc.com)
+ *
+ * Licensed under The MIT License
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright Copyright 2020, Cake Development Corporation (https://www.cakedc.com)
+ * @license   MIT License (http://www.opensource.org/licenses/mit-license.php)
+ */
+
+namespace CakeDC\MyPlugin\Controller;
+
+use Cake\Controller\Controller;
+
+class NotesController extends Controller
+{
+
+    /**
+     * Test ControllerFetchTableDynamicReturnTypeExtension with fetchTable using controller's className to extract
+     * correct table class
+     *
+     * @return void
+     */
+    public function addComplete()
+    {
+        $data = $this->fetchTable()->complete();
+        $this->set(compact('data'));
+    }
+}

--- a/tests/test_plugin/Controller/NotesController.php
+++ b/tests/test_plugin/Controller/NotesController.php
@@ -17,7 +17,6 @@ use Cake\Controller\Controller;
 
 class NotesController extends Controller
 {
-
     /**
      * Test ControllerFetchTableDynamicReturnTypeExtension with fetchTable using controller's className to extract
      * correct table class

--- a/tests/test_plugin/Controller/NotesController.php
+++ b/tests/test_plugin/Controller/NotesController.php
@@ -2,12 +2,12 @@
 declare(strict_types=1);
 
 /**
- * Copyright 2020, Cake Development Corporation (https://www.cakedc.com)
+ * Copyright 2023, Cake Development Corporation (https://www.cakedc.com)
  *
  * Licensed under The MIT License
  * Redistributions of files must retain the above copyright notice.
  *
- * @copyright Copyright 2020, Cake Development Corporation (https://www.cakedc.com)
+ * @copyright Copyright 2023, Cake Development Corporation (https://www.cakedc.com)
  * @license   MIT License (http://www.opensource.org/licenses/mit-license.php)
  */
 

--- a/tests/test_plugin/Model/Table/NotesTable.php
+++ b/tests/test_plugin/Model/Table/NotesTable.php
@@ -1,0 +1,43 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * Copyright 2023, Cake Development Corporation (https://www.cakedc.com)
+ *
+ * Licensed under The MIT License
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright Copyright 2023, Cake Development Corporation (https://www.cakedc.com)
+ * @license   MIT License (http://www.opensource.org/licenses/mit-license.php)
+ */
+
+namespace CakeDC\MyPlugin\Model\Table;
+
+use Cake\ORM\Table;
+
+class NotesTable extends Table
+{
+    /**
+     * @return string[]
+     */
+    public function complete(): array
+    {
+        return ['note' => 'completed'];
+    }
+
+    /**
+     * @return string[]
+     */
+    public function info(): array
+    {
+        return ['note' => 'info'];
+    }
+
+    /**
+     * @return string[]
+     */
+    public function notice(): array
+    {
+        return ['note' => 'notice'];
+    }
+}


### PR DESCRIPTION
- Check defined $defaultTable when calling LocatorAwareTrait::fetchTable without arguments
- For controllers when calling `fetchTable` without arguments and not defined custom $defaultTable try to detect the table based on the Controller's className
- Fixed console helper extension to use ucfirst as is done in the method ConsoleIo::helper
- phpcs fixes
- phpstan fixes