### PR TITLE
Feature/new rules 2410

### DIFF
--- a/.semver
+++ b/.semver
@@ -1,5 +1,5 @@
 ---
 :major: 3
-:minor: 1
-:patch: 2
+:minor: 2
+:patch: 0
 :special: ''

--- a/README.md
+++ b/README.md
@@ -138,6 +138,17 @@ This rule check if the options (args) passed to Table::find and SelectQuery are 
 ### TableGetMatchOptionsTypesRule
 This rule check if the options (args) passed to Table::get are valid find options types.
 
+### DisallowEntityArrayAccessRule
+This rule check disallow array access to entity in favor of object notation, is easier to detect a wrong property and to refactor code.
+
+To enable this rule update your phpstan.neon with:
+
+```
+parameters:
+	cakeDC:
+	 	disallowEntityArrayAccessRule: true
+```
+
 ### How to disable a rule
 Each rule has a parameter in cakeDC 'namespace' to enable or disable, it is the same name of the
 rule with first letter in lowercase.

--- a/README.md
+++ b/README.md
@@ -90,7 +90,8 @@ Features included:
 1. Provide correct return type for `Cake\ORM\Table::saveManyOrFail` based on the first argument passed
 1. Provide correct return type for `Cake\ORM\Table::deleteMany` based on the first argument passed
 1. Provide correct return type for `Cake\ORM\Table::deleteManyOrFail` based on the first argument passed
-
+1. Provide correct return type for `Cake\ORM\Locator\LocatorAwareTrait::fetchTable` based on the first argument passed
+1. Provide correct return type for `Cake\Mailer\MailerAwareTrait::getMailer` based on the first argument passed
 
 <details>
       <summary>Examples:</summary>

--- a/README.md
+++ b/README.md
@@ -131,13 +131,16 @@ This rule check if association options are valid option types based on what each
 Table::hasMany, Table::belongsToMany, Table::hasOne and AssociationCollection::load.
 
 ### AddBehaviorExistsClassRule
-This rule check if the target behavior has a valid table class when calling to Table::addBehavior and BehaviorRegistry::load.
+This rule check if the target behavior has a valid class when calling to Table::addBehavior and BehaviorRegistry::load.
 
 ### DisallowEntityArrayAccessRule
 This rule check disallow array access to entity in favor of object notation, is easier to detect a wrong property and to refactor code.
 
 ### GetMailerExistsClassRule
 This rule check if the target mailer is a valid class when calling to Cake\Mailer\MailerAwareTrait::getMailer.
+
+### LoadComponentExistsClassRule
+This rule check if the target component has a valid class when calling to Controller::loadComponent and ComponentRegistry::load.
 
 ### OrmSelectQueryFindMatchOptionsTypesRule
 This rule check if the options (args) passed to Table::find and SelectQuery are valid find options types.

--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ Table::hasMany, Table::belongsToMany, Table::hasOne and AssociationCollection::l
 This rule check if the target behavior has a valid class when calling to Table::addBehavior and BehaviorRegistry::load.
 
 ### DisallowEntityArrayAccessRule
-This rule check disallow array access to entity in favor of object notation, is easier to detect a wrong property and to refactor code.
+This rule disallow array access to entity in favor of object notation, is easier to detect a wrong property and to refactor code.
 
 ### GetMailerExistsClassRule
 This rule check if the target mailer is a valid class when calling to Cake\Mailer\MailerAwareTrait::getMailer.

--- a/README.md
+++ b/README.md
@@ -133,14 +133,17 @@ Table::hasMany, Table::belongsToMany, Table::hasOne and AssociationCollection::l
 ### AddBehaviorExistsClassRule
 This rule check if the target behavior has a valid table class when calling to Table::addBehavior and BehaviorRegistry::load.
 
+### DisallowEntityArrayAccessRule
+This rule check disallow array access to entity in favor of object notation, is easier to detect a wrong property and to refactor code.
+
+### GetMailerExistsClassRule
+This rule check if the target mailer is a valid class when calling to Cake\Mailer\MailerAwareTrait::getMailer.
+
 ### OrmSelectQueryFindMatchOptionsTypesRule
 This rule check if the options (args) passed to Table::find and SelectQuery are valid find options types.
 
 ### TableGetMatchOptionsTypesRule
 This rule check if the options (args) passed to Table::get are valid find options types.
-
-### DisallowEntityArrayAccessRule
-This rule check disallow array access to entity in favor of object notation, is easier to detect a wrong property and to refactor code.
 
 To enable this rule update your phpstan.neon with:
 

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -7,3 +7,5 @@ parameters:
     level: max
     checkGenericClassInNonGenericObjectType: false
     treatPhpDocTypesAsCertain: false
+    cakeDC:
+        disallowEntityArrayAccessRule: true

--- a/rules.neon
+++ b/rules.neon
@@ -6,6 +6,7 @@ parameters:
 	 	tableGetMatchOptionsTypesRule: true
 	 	ormSelectQueryFindMatchOptionsTypesRule: true
 	 	disallowEntityArrayAccessRule: false
+	 	getMailerExistsClassRule: true,
 
 parametersSchema:
 	cakeDC: structure([
@@ -15,6 +16,7 @@ parametersSchema:
 		tableGetMatchOptionsTypesRule: anyOf(bool(), arrayOf(bool()))
 		ormSelectQueryFindMatchOptionsTypesRule: anyOf(bool(), arrayOf(bool()))
 		disallowEntityArrayAccessRule: anyOf(bool(), arrayOf(bool()))
+		getMailerExistsClassRule: anyOf(bool(), arrayOf(bool()))
 	])
 
 conditionalTags:
@@ -32,6 +34,8 @@ conditionalTags:
 		phpstan.rules.rule: %cakeDC.ormSelectQueryFindMatchOptionsTypesRule%
 	CakeDC\PHPStan\Rule\Model\DisallowEntityArrayAccessRule:
 		phpstan.rules.rule: %cakeDC.disallowEntityArrayAccessRule%
+	CakeDC\PHPStan\Rule\Model\GetMailerExistsClassRule:
+		phpstan.rules.rule: %cakeDC.getMailerExistsClassRule%
 services:
 	-
 		class: CakeDC\PHPStan\Visitor\AddAssociationSetClassNameVisitor
@@ -47,3 +51,5 @@ services:
 		class: CakeDC\PHPStan\Rule\Model\OrmSelectQueryFindMatchOptionsTypesRule
 	-
 		class: CakeDC\PHPStan\Rule\Model\DisallowEntityArrayAccessRule
+	-
+		class: CakeDC\PHPStan\Rule\Model\GetMailerExistsClassRule

--- a/rules.neon
+++ b/rules.neon
@@ -6,7 +6,7 @@ parameters:
 	 	tableGetMatchOptionsTypesRule: true
 	 	ormSelectQueryFindMatchOptionsTypesRule: true
 	 	disallowEntityArrayAccessRule: false
-	 	getMailerExistsClassRule: true,
+	 	getMailerExistsClassRule: true
 
 parametersSchema:
 	cakeDC: structure([
@@ -34,7 +34,7 @@ conditionalTags:
 		phpstan.rules.rule: %cakeDC.ormSelectQueryFindMatchOptionsTypesRule%
 	CakeDC\PHPStan\Rule\Model\DisallowEntityArrayAccessRule:
 		phpstan.rules.rule: %cakeDC.disallowEntityArrayAccessRule%
-	CakeDC\PHPStan\Rule\Model\GetMailerExistsClassRule:
+	CakeDC\PHPStan\Rule\Mailer\GetMailerExistsClassRule:
 		phpstan.rules.rule: %cakeDC.getMailerExistsClassRule%
 services:
 	-
@@ -52,4 +52,4 @@ services:
 	-
 		class: CakeDC\PHPStan\Rule\Model\DisallowEntityArrayAccessRule
 	-
-		class: CakeDC\PHPStan\Rule\Model\GetMailerExistsClassRule
+		class: CakeDC\PHPStan\Rule\Mailer\GetMailerExistsClassRule

--- a/rules.neon
+++ b/rules.neon
@@ -7,7 +7,7 @@ parameters:
 	 	ormSelectQueryFindMatchOptionsTypesRule: true
 	 	disallowEntityArrayAccessRule: false
 	 	getMailerExistsClassRule: true
-
+	 	loadComponentExistsClassRule: true
 parametersSchema:
 	cakeDC: structure([
 		addAssociationExistsTableClassRule: anyOf(bool(), arrayOf(bool()))
@@ -17,28 +17,34 @@ parametersSchema:
 		ormSelectQueryFindMatchOptionsTypesRule: anyOf(bool(), arrayOf(bool()))
 		disallowEntityArrayAccessRule: anyOf(bool(), arrayOf(bool()))
 		getMailerExistsClassRule: anyOf(bool(), arrayOf(bool()))
+		loadComponentExistsClassRule: anyOf(bool(), arrayOf(bool()))
 	])
 
 conditionalTags:
 	CakeDC\PHPStan\Visitor\AddAssociationSetClassNameVisitor:
 		phpstan.parser.richParserNodeVisitor: %cakeDC.addAssociationExistsTableClassRule%
+	CakeDC\PHPStan\Rule\Controller\LoadComponentExistsClassRule:
+		phpstan.rules.rule: %cakeDC.loadComponentExistsClassRule%
 	CakeDC\PHPStan\Rule\Model\AddAssociationExistsTableClassRule:
 		phpstan.rules.rule: %cakeDC.addAssociationExistsTableClassRule%
 	CakeDC\PHPStan\Rule\Model\AddAssociationMatchOptionsTypesRule:
 		phpstan.rules.rule: %cakeDC.addAssociationMatchOptionsTypesRule%
 	CakeDC\PHPStan\Rule\Model\AddBehaviorExistsClassRule:
 		phpstan.rules.rule: %cakeDC.addBehaviorExistsClassRule%
-	CakeDC\PHPStan\Rule\Model\TableGetMatchOptionsTypesRule:
-		phpstan.rules.rule: %cakeDC.tableGetMatchOptionsTypesRule%
-	CakeDC\PHPStan\Rule\Model\OrmSelectQueryFindMatchOptionsTypesRule:
-		phpstan.rules.rule: %cakeDC.ormSelectQueryFindMatchOptionsTypesRule%
 	CakeDC\PHPStan\Rule\Model\DisallowEntityArrayAccessRule:
 		phpstan.rules.rule: %cakeDC.disallowEntityArrayAccessRule%
 	CakeDC\PHPStan\Rule\Mailer\GetMailerExistsClassRule:
 		phpstan.rules.rule: %cakeDC.getMailerExistsClassRule%
+	CakeDC\PHPStan\Rule\Model\TableGetMatchOptionsTypesRule:
+		phpstan.rules.rule: %cakeDC.tableGetMatchOptionsTypesRule%
+	CakeDC\PHPStan\Rule\Model\OrmSelectQueryFindMatchOptionsTypesRule:
+		phpstan.rules.rule: %cakeDC.ormSelectQueryFindMatchOptionsTypesRule%
+
 services:
 	-
 		class: CakeDC\PHPStan\Visitor\AddAssociationSetClassNameVisitor
+	-
+		class: CakeDC\PHPStan\Rule\Controller\LoadComponentExistsClassRule
 	-
 		class: CakeDC\PHPStan\Rule\Model\AddAssociationExistsTableClassRule
 	-
@@ -46,10 +52,10 @@ services:
 	-
 		class: CakeDC\PHPStan\Rule\Model\AddBehaviorExistsClassRule
 	-
-		class: CakeDC\PHPStan\Rule\Model\TableGetMatchOptionsTypesRule
-	-
-		class: CakeDC\PHPStan\Rule\Model\OrmSelectQueryFindMatchOptionsTypesRule
-	-
 		class: CakeDC\PHPStan\Rule\Model\DisallowEntityArrayAccessRule
 	-
 		class: CakeDC\PHPStan\Rule\Mailer\GetMailerExistsClassRule
+	-
+		class: CakeDC\PHPStan\Rule\Model\TableGetMatchOptionsTypesRule
+	-
+		class: CakeDC\PHPStan\Rule\Model\OrmSelectQueryFindMatchOptionsTypesRule

--- a/rules.neon
+++ b/rules.neon
@@ -5,6 +5,7 @@ parameters:
 	 	addBehaviorExistsClassRule: true
 	 	tableGetMatchOptionsTypesRule: true
 	 	ormSelectQueryFindMatchOptionsTypesRule: true
+	 	disallowEntityArrayAccessRule: false
 
 parametersSchema:
 	cakeDC: structure([
@@ -13,6 +14,7 @@ parametersSchema:
 		addBehaviorExistsClassRule: anyOf(bool(), arrayOf(bool()))
 		tableGetMatchOptionsTypesRule: anyOf(bool(), arrayOf(bool()))
 		ormSelectQueryFindMatchOptionsTypesRule: anyOf(bool(), arrayOf(bool()))
+		disallowEntityArrayAccessRule: anyOf(bool(), arrayOf(bool()))
 	])
 
 conditionalTags:
@@ -28,7 +30,8 @@ conditionalTags:
 		phpstan.rules.rule: %cakeDC.tableGetMatchOptionsTypesRule%
 	CakeDC\PHPStan\Rule\Model\OrmSelectQueryFindMatchOptionsTypesRule:
 		phpstan.rules.rule: %cakeDC.ormSelectQueryFindMatchOptionsTypesRule%
-
+	CakeDC\PHPStan\Rule\Model\DisallowEntityArrayAccessRule:
+		phpstan.rules.rule: %cakeDC.disallowEntityArrayAccessRule%
 services:
 	-
 		class: CakeDC\PHPStan\Visitor\AddAssociationSetClassNameVisitor
@@ -42,3 +45,5 @@ services:
 		class: CakeDC\PHPStan\Rule\Model\TableGetMatchOptionsTypesRule
 	-
 		class: CakeDC\PHPStan\Rule\Model\OrmSelectQueryFindMatchOptionsTypesRule
+	-
+		class: CakeDC\PHPStan\Rule\Model\DisallowEntityArrayAccessRule

--- a/src/Rule/Controller/LoadComponentExistsClassRule.php
+++ b/src/Rule/Controller/LoadComponentExistsClassRule.php
@@ -1,0 +1,71 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * Copyright 2024, Cake Development Corporation (https://www.cakedc.com)
+ *
+ * Licensed under The MIT License
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright Copyright 2024, Cake Development Corporation (https://www.cakedc.com)
+ * @license   MIT License (http://www.opensource.org/licenses/mit-license.php)
+ */
+
+namespace CakeDC\PHPStan\Rule\Controller;
+
+use Cake\Controller\ComponentRegistry;
+use CakeDC\PHPStan\Rule\LoadObjectExistsCakeClassRule;
+use CakeDC\PHPStan\Utility\CakeNameRegistry;
+
+class LoadComponentExistsClassRule extends LoadObjectExistsCakeClassRule
+{
+    /**
+     * @var string
+     */
+    protected string $identifier = 'cake.loadComponent.existClass';
+
+    /**
+     * @var array<string>
+     */
+    protected array $sourceMethods = [
+        'loadComponent',
+    ];
+
+    /**
+     * @var array<string>
+     */
+    protected array $componentRegistryMethods = [
+        'load',
+    ];
+
+    /**
+     * @inheritDoc
+     */
+    protected function getTargetClassName(string $name): ?string
+    {
+        return CakeNameRegistry::getComponentClassName($name);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    protected function getDetails(string $reference, array $args): ?array
+    {
+        if (str_ends_with($reference, 'Controller')) {
+            return [
+                'alias' => $args[0] ?? null,
+                'options' => $args[1] ?? null,
+                'sourceMethods' => $this->sourceMethods,
+            ];
+        }
+        if ($reference === ComponentRegistry::class) {
+            return [
+                'alias' => $args[0] ?? null,
+                'options' => $args[1] ?? null,
+                'sourceMethods' => $this->componentRegistryMethods,
+            ];
+        }
+
+        return null;
+    }
+}

--- a/src/Rule/LoadObjectExistsCakeClassRule.php
+++ b/src/Rule/LoadObjectExistsCakeClassRule.php
@@ -73,7 +73,7 @@ abstract class LoadObjectExistsCakeClassRule implements Rule
                 $details['options']
             );
         }
-        if ($this->getTargetClassName($inputClassName)) {
+        if ($inputClassName === null || $this->getTargetClassName($inputClassName)) {
             return [];
         }
 
@@ -92,12 +92,11 @@ abstract class LoadObjectExistsCakeClassRule implements Rule
     /**
      * @param \PhpParser\Node\Scalar\String_ $nameArg
      * @param \PhpParser\Node\Arg|null $options
-     * @return string
+     * @return string|null
      */
-    protected function getInputClassName(String_ $nameArg, ?Arg $options): string
+    protected function getInputClassName(String_ $nameArg, ?Arg $options): ?string
     {
         $className = $nameArg->value;
-
         if (
             $options === null
             || !$options->value instanceof Node\Expr\Array_
@@ -112,10 +111,8 @@ abstract class LoadObjectExistsCakeClassRule implements Rule
             ) {
                 continue;
             }
-            $name = $this->parseClassNameFromExprTrait($item->value);
-            if ($name !== null) {
-                return $name;
-            }
+
+            return $this->parseClassNameFromExprTrait($item->value);
         }
 
         return $className;

--- a/src/Rule/LoadObjectExistsCakeClassRule.php
+++ b/src/Rule/LoadObjectExistsCakeClassRule.php
@@ -16,6 +16,7 @@ namespace CakeDC\PHPStan\Rule;
 use CakeDC\PHPStan\Rule\Traits\ParseClassNameFromArgTrait;
 use PhpParser\Node;
 use PhpParser\Node\Arg;
+use PhpParser\Node\Expr\ConstFetch;
 use PhpParser\Node\Expr\MethodCall;
 use PhpParser\Node\Scalar\String_;
 use PHPStan\Analyser\Scope;
@@ -110,6 +111,9 @@ abstract class LoadObjectExistsCakeClassRule implements Rule
                 || $item->key->value !== 'className'
             ) {
                 continue;
+            }
+            if ($item->value instanceof ConstFetch && $item->value->name->toString() === 'null') {
+                return $className;
             }
 
             return $this->parseClassNameFromExprTrait($item->value);

--- a/src/Rule/Mailer/GetMailerExistsClassRule.php
+++ b/src/Rule/Mailer/GetMailerExistsClassRule.php
@@ -13,10 +13,8 @@ declare(strict_types=1);
 
 namespace CakeDC\PHPStan\Rule\Mailer;
 
-use CakeDC\PHPStan\Rule\LoadObjectExistsCakeClassRule;
 use CakeDC\PHPStan\Utility\CakeNameRegistry;
 use PhpParser\Node;
-use PhpParser\Node\Arg;
 use PhpParser\Node\Expr\MethodCall;
 use PhpParser\Node\Scalar\String_;
 use PHPStan\Analyser\Scope;
@@ -37,6 +35,7 @@ class GetMailerExistsClassRule implements Rule
     {
         return MethodCall::class;
     }
+
     /**
      * @param \PhpParser\Node $node
      * @param \PHPStan\Analyser\Scope $scope
@@ -45,7 +44,8 @@ class GetMailerExistsClassRule implements Rule
     public function processNode(Node $node, Scope $scope): array
     {
         assert($node instanceof MethodCall);
-        if (!$node->name instanceof Node\Identifier
+        if (
+            !$node->name instanceof Node\Identifier
             || $node->name->name !== 'getMailer'
         ) {
             return [];
@@ -102,6 +102,7 @@ class GetMailerExistsClassRule implements Rule
                 'options' => [],
             ];
         }
+
         return null;
     }
 }

--- a/src/Rule/Mailer/GetMailerExistsClassRule.php
+++ b/src/Rule/Mailer/GetMailerExistsClassRule.php
@@ -1,0 +1,107 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * Copyright 2024, Cake Development Corporation (https://www.cakedc.com)
+ *
+ * Licensed under The MIT License
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright Copyright 2024, Cake Development Corporation (https://www.cakedc.com)
+ * @license   MIT License (http://www.opensource.org/licenses/mit-license.php)
+ */
+
+namespace CakeDC\PHPStan\Rule\Mailer;
+
+use CakeDC\PHPStan\Rule\LoadObjectExistsCakeClassRule;
+use CakeDC\PHPStan\Utility\CakeNameRegistry;
+use PhpParser\Node;
+use PhpParser\Node\Arg;
+use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Scalar\String_;
+use PHPStan\Analyser\Scope;
+use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleErrorBuilder;
+
+class GetMailerExistsClassRule implements Rule
+{
+    /**
+     * @var string
+     */
+    protected string $identifier = 'cake.getMailer.existClass';
+
+    /**
+     * @return string
+     */
+    public function getNodeType(): string
+    {
+        return MethodCall::class;
+    }
+    /**
+     * @param \PhpParser\Node $node
+     * @param \PHPStan\Analyser\Scope $scope
+     * @return array<\PHPStan\Rules\RuleError>
+     */
+    public function processNode(Node $node, Scope $scope): array
+    {
+        assert($node instanceof MethodCall);
+        if (!$node->name instanceof Node\Identifier
+            || $node->name->name !== 'getMailer'
+        ) {
+            return [];
+        }
+
+        $args = $node->getArgs();
+        if (!isset($args[0])) {
+            return [];
+        }
+        $value = $args[0]->value;
+        if (!$value instanceof String_) {
+            return [];
+        }
+        $callerType = $scope->getType($node->var);
+        $reflection = $callerType->getClassReflection();
+        if ($reflection === null) {
+            return [];
+        }
+
+        if (CakeNameRegistry::getMailerClassName($value->value)) {
+            return [];
+        }
+
+        return [
+            RuleErrorBuilder::message(sprintf(
+                'Call to %s::%s could not find the class for "%s"',
+                $reflection->getName(),
+                $node->name->name,
+                $value->value,
+            ))
+            ->identifier($this->identifier)
+            ->build(),
+        ];
+    }
+
+    /**
+     * @inheritDoc
+     */
+    protected function getTargetClassName(string $name): ?string
+    {
+        return CakeNameRegistry::getMailerClassName($name);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    protected function getDetails(string $reference, array $args): ?array
+    {
+        var_dump(['reference' => $reference]);
+        if (str_ends_with($reference, 'Table')) {
+            return [
+                'alias' => $args[0] ?? null,
+                'sourceMethods' => 'getMailer',
+                'options' => [],
+            ];
+        }
+        return null;
+    }
+}

--- a/src/Rule/Mailer/GetMailerExistsClassRule.php
+++ b/src/Rule/Mailer/GetMailerExistsClassRule.php
@@ -20,6 +20,7 @@ use PhpParser\Node\Scalar\String_;
 use PHPStan\Analyser\Scope;
 use PHPStan\Rules\Rule;
 use PHPStan\Rules\RuleErrorBuilder;
+use PHPStan\Type\ThisType;
 
 class GetMailerExistsClassRule implements Rule
 {
@@ -60,10 +61,10 @@ class GetMailerExistsClassRule implements Rule
             return [];
         }
         $callerType = $scope->getType($node->var);
-        $reflection = $callerType->getClassReflection();
-        if ($reflection === null) {
+        if (!$callerType instanceof ThisType) {
             return [];
         }
+        $reflection = $callerType->getClassReflection();
 
         if (CakeNameRegistry::getMailerClassName($value->value)) {
             return [];
@@ -79,30 +80,5 @@ class GetMailerExistsClassRule implements Rule
             ->identifier($this->identifier)
             ->build(),
         ];
-    }
-
-    /**
-     * @inheritDoc
-     */
-    protected function getTargetClassName(string $name): ?string
-    {
-        return CakeNameRegistry::getMailerClassName($name);
-    }
-
-    /**
-     * @inheritDoc
-     */
-    protected function getDetails(string $reference, array $args): ?array
-    {
-        var_dump(['reference' => $reference]);
-        if (str_ends_with($reference, 'Table')) {
-            return [
-                'alias' => $args[0] ?? null,
-                'sourceMethods' => 'getMailer',
-                'options' => [],
-            ];
-        }
-
-        return null;
     }
 }

--- a/src/Rule/Model/BlockEntityArrayAccessRule.php
+++ b/src/Rule/Model/BlockEntityArrayAccessRule.php
@@ -1,0 +1,47 @@
+<?php
+declare(strict_types=1);
+
+namespace CakeDC\PHPStan\Rule\Model;
+
+use Cake\Datasource\EntityInterface;
+use PhpParser\Node;
+use PHPStan\Analyser\Scope;
+use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleErrorBuilder;
+use PHPStan\Type\ObjectType;
+
+class BlockEntityArrayAccessRule implements Rule
+{
+    /**
+     * @return string
+     */
+    public function getNodeType(): string
+    {
+        return Node\Expr\ArrayDimFetch::class;
+    }
+
+    /**
+     * @param \PhpParser\Node $node
+     * @param \PHPStan\Analyser\Scope $scope
+     * @return array<\PHPStan\Rules\RuleError>
+     * @throws \PHPStan\ShouldNotHappenException
+     * @throws \PHPStan\Reflection\MissingMethodFromReflectionException
+     */
+    public function processNode(Node $node, Scope $scope): array
+    {
+        $type = $scope->getType($node->var);
+
+        if (!$type instanceof ObjectType || !is_a($type->getClassName(), EntityInterface::class, true)) {
+            return [];
+        }
+
+        return [
+            RuleErrorBuilder::message(sprintf(
+                'Array access to entity to %s is not allowed, access as object instead',
+                $type->getClassName(),
+            ))
+            ->identifier('cake.entity.arrayAccess')
+            ->build(),
+        ];
+    }
+}

--- a/src/Rule/Model/DisallowEntityArrayAccessRule.php
+++ b/src/Rule/Model/DisallowEntityArrayAccessRule.php
@@ -10,7 +10,7 @@ use PHPStan\Rules\Rule;
 use PHPStan\Rules\RuleErrorBuilder;
 use PHPStan\Type\ObjectType;
 
-class BlockEntityArrayAccessRule implements Rule
+class DisallowEntityArrayAccessRule implements Rule
 {
     /**
      * @return string

--- a/src/Rule/Model/DisallowEntityArrayAccessRule.php
+++ b/src/Rule/Model/DisallowEntityArrayAccessRule.php
@@ -5,6 +5,7 @@ namespace CakeDC\PHPStan\Rule\Model;
 
 use Cake\Datasource\EntityInterface;
 use PhpParser\Node;
+use PhpParser\Node\Expr\ArrayDimFetch;
 use PHPStan\Analyser\Scope;
 use PHPStan\Rules\Rule;
 use PHPStan\Rules\RuleErrorBuilder;
@@ -17,7 +18,7 @@ class DisallowEntityArrayAccessRule implements Rule
      */
     public function getNodeType(): string
     {
-        return Node\Expr\ArrayDimFetch::class;
+        return ArrayDimFetch::class;
     }
 
     /**
@@ -29,8 +30,8 @@ class DisallowEntityArrayAccessRule implements Rule
      */
     public function processNode(Node $node, Scope $scope): array
     {
+        assert($node instanceof ArrayDimFetch);
         $type = $scope->getType($node->var);
-
         if (!$type instanceof ObjectType || !is_a($type->getClassName(), EntityInterface::class, true)) {
             return [];
         }

--- a/src/Traits/IsFromTargetTrait.php
+++ b/src/Traits/IsFromTargetTrait.php
@@ -1,0 +1,29 @@
+<?php
+declare(strict_types=1);
+
+namespace CakeDC\PHPStan\Traits;
+
+use PHPStan\Reflection\ClassReflection;
+
+trait IsFromTargetTrait
+{
+    /**
+     * @param \PHPStan\Reflection\ClassReflection $reflection
+     * @return bool
+     */
+    protected function isFromTargetTrait(ClassReflection $reflection, string $targetTrait): bool
+    {
+        foreach ($reflection->getTraits() as $trait) {
+            if ($trait->getName() === $targetTrait) {
+                return true;
+            }
+        }
+        foreach ($reflection->getParents() as $parent) {
+            if ($this->isFromTargetTrait($parent, $targetTrait)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/src/Type/BaseTraitExpressionTypeResolverExtension.php
+++ b/src/Type/BaseTraitExpressionTypeResolverExtension.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace CakeDC\PHPStan\Type;
 
+use CakeDC\PHPStan\Traits\IsFromTargetTrait;
 use CakeDC\PHPStan\Utility\CakeNameRegistry;
 use PhpParser\Node\Expr;
 use PhpParser\Node\Identifier;
@@ -27,6 +28,8 @@ use ReflectionException;
 
 class BaseTraitExpressionTypeResolverExtension implements ExpressionTypeResolverExtension
 {
+    use IsFromTargetTrait;
+
     /**
      * TableLocatorDynamicReturnTypeExtension constructor.
      *
@@ -63,7 +66,7 @@ class BaseTraitExpressionTypeResolverExtension implements ExpressionTypeResolver
             return null;
         }
         $reflection = $callerType->getClassReflection();
-        if ($reflection === null || !$this->isFromTargetTrait($reflection)) {
+        if ($reflection === null || !$this->isFromTargetTrait($reflection, $this->targetTrait)) {
             return null;
         }
 
@@ -78,26 +81,6 @@ class BaseTraitExpressionTypeResolverExtension implements ExpressionTypeResolver
         }
 
         return null;
-    }
-
-    /**
-     * @param \PHPStan\Reflection\ClassReflection $reflection
-     * @return bool
-     */
-    protected function isFromTargetTrait(ClassReflection $reflection): bool
-    {
-        foreach ($reflection->getTraits() as $trait) {
-            if ($trait->getName() === $this->targetTrait) {
-                return true;
-            }
-        }
-        foreach ($reflection->getParents() as $parent) {
-            if ($this->isFromTargetTrait($parent)) {
-                return true;
-            }
-        }
-
-        return false;
     }
 
     /**

--- a/src/Utility/CakeNameRegistry.php
+++ b/src/Utility/CakeNameRegistry.php
@@ -66,4 +66,15 @@ class CakeNameRegistry
             '%s\\Model\\Table\\%sTable',
         ]);
     }
+
+    /**
+     * @param string $name
+     * @return string|null
+     */
+    public static function getMailerClassName(string $name): ?string
+    {
+        return static::getClassName($name, [
+            '%s\\Mailer\\%sMailer',
+        ]);
+    }
 }

--- a/src/Utility/CakeNameRegistry.php
+++ b/src/Utility/CakeNameRegistry.php
@@ -48,6 +48,18 @@ class CakeNameRegistry
      * @param string $name
      * @return string|null
      */
+    public static function getComponentClassName(string $name): ?string
+    {
+        return static::getClassName($name, [
+            '%s\\Controller\\Component\\%sComponent',
+            '%s\\Controller\\Component\\%sComponent',
+        ]);
+    }
+
+    /**
+     * @param string $name
+     * @return string|null
+     */
     public static function getBehaviorClassName(string $name): ?string
     {
         return static::getClassName($name, [

--- a/tests/TestCase/Rule/Controller/Fake/FailingLoadComponentController.php
+++ b/tests/TestCase/Rule/Controller/Fake/FailingLoadComponentController.php
@@ -1,0 +1,32 @@
+<?php
+declare(strict_types=1);
+
+namespace CakeDC\PHPStan\Test\TestCase\Rule\Mailer\Fake;
+
+use Cake\Controller\Controller;
+
+class FailingLoadComponentController extends Controller
+{
+    /**
+     * @inheritDoc
+     */
+    public function initialize(): void
+    {
+        parent::initialize();
+        $this->loadComponent('Warning')->testWarning();
+        $this->loadComponent('FormProtection');
+        $this->loadComponent('CrazyWorld');
+        $this->loadComponent('HelloWorld', [
+            'className' => null,//when null should ignore and try with name argument. Must cause error
+        ]);
+        $this->loadComponent('LegacyFlash', [
+            'className' => 'Flash',//Should use this instead of name argument. Not error
+        ]);
+        $this->loadComponent('Faker', [
+            'className' => 'CrayFaker',//Should use this instead of name argument. Must cause error
+        ]);
+        $this->loadComponent('AppFaker', [
+            'className' => 'Faker',//Should use this instead of name argument. Not error
+        ]);
+    }
+}

--- a/tests/TestCase/Rule/Controller/Fake/FailingLoadComponentController.php
+++ b/tests/TestCase/Rule/Controller/Fake/FailingLoadComponentController.php
@@ -1,7 +1,7 @@
 <?php
 declare(strict_types=1);
 
-namespace CakeDC\PHPStan\Test\TestCase\Rule\Mailer\Fake;
+namespace CakeDC\PHPStan\Test\TestCase\Rule\Controller\Fake;
 
 use Cake\Controller\Controller;
 

--- a/tests/TestCase/Rule/Controller/LoadComponentExistsClassRuleTest.php
+++ b/tests/TestCase/Rule/Controller/LoadComponentExistsClassRuleTest.php
@@ -37,15 +37,15 @@ class LoadComponentExistsClassRuleTest extends RuleTestCase
         // each error consists of the asserted error message, and the asserted error file line
         $this->analyse([__DIR__ . '/Fake/FailingLoadComponentController.php'], [
             [
-                'Call to CakeDC\PHPStan\Test\TestCase\Rule\Mailer\Fake\FailingLoadComponentController::loadComponent could not find the class for "CrazyWorld"',
+                'Call to CakeDC\PHPStan\Test\TestCase\Rule\Controller\Fake\FailingLoadComponentController::loadComponent could not find the class for "CrazyWorld"',
                 18,
             ],
             [
-                'Call to CakeDC\PHPStan\Test\TestCase\Rule\Mailer\Fake\FailingLoadComponentController::loadComponent could not find the class for "HelloWorld"',
+                'Call to CakeDC\PHPStan\Test\TestCase\Rule\Controller\Fake\FailingLoadComponentController::loadComponent could not find the class for "HelloWorld"',
                 19,
             ],
             [
-                'Call to CakeDC\PHPStan\Test\TestCase\Rule\Mailer\Fake\FailingLoadComponentController::loadComponent could not find the class for "CrayFaker"',
+                'Call to CakeDC\PHPStan\Test\TestCase\Rule\Controller\Fake\FailingLoadComponentController::loadComponent could not find the class for "CrayFaker"',
                 25,
             ],
         ]);

--- a/tests/TestCase/Rule/Controller/LoadComponentExistsClassRuleTest.php
+++ b/tests/TestCase/Rule/Controller/LoadComponentExistsClassRuleTest.php
@@ -1,0 +1,53 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * Copyright 2024, Cake Development Corporation (https://www.cakedc.com)
+ *
+ * Licensed under The MIT License
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright Copyright 2024, Cake Development Corporation (https://www.cakedc.com)
+ * @license   MIT License (http://www.opensource.org/licenses/mit-license.php)
+ */
+namespace CakeDC\PHPStan\Test\TestCase\Rule\Controller;
+
+use CakeDC\PHPStan\Rule\Controller\LoadComponentExistsClassRule;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+
+class LoadComponentExistsClassRuleTest extends RuleTestCase
+{
+    /**
+     * @return \PHPStan\Rules\Rule
+     */
+    protected function getRule(): Rule
+    {
+        // getRule() method needs to return an instance of the tested rule
+        return new LoadComponentExistsClassRule();
+    }
+
+    /**
+     * @return void
+     */
+    public function testRule(): void
+    {
+        // first argument: path to the example file that contains some errors that should be reported by MyRule
+        // second argument: an array of expected errors,
+        // each error consists of the asserted error message, and the asserted error file line
+        $this->analyse([__DIR__ . '/Fake/FailingLoadComponentController.php'], [
+            [
+                'Call to CakeDC\PHPStan\Test\TestCase\Rule\Mailer\Fake\FailingLoadComponentController::loadComponent could not find the class for "CrazyWorld"',
+                18,
+            ],
+            [
+                'Call to CakeDC\PHPStan\Test\TestCase\Rule\Mailer\Fake\FailingLoadComponentController::loadComponent could not find the class for "HelloWorld"',
+                19,
+            ],
+            [
+                'Call to CakeDC\PHPStan\Test\TestCase\Rule\Mailer\Fake\FailingLoadComponentController::loadComponent could not find the class for "CrayFaker"',
+                25,
+            ],
+        ]);
+    }
+}

--- a/tests/TestCase/Rule/Mailer/Fake/FailingGetMailerUsageLogic.php
+++ b/tests/TestCase/Rule/Mailer/Fake/FailingGetMailerUsageLogic.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 namespace CakeDC\PHPStan\Test\TestCase\Rule\Mailer\Fake;
 
 use Cake\Mailer\MailerAwareTrait;
-use Cake\ORM\Locator\LocatorAwareTrait;
 
 class FailingGetMailerUsageLogic
 {

--- a/tests/TestCase/Rule/Mailer/Fake/FailingGetMailerUsageLogic.php
+++ b/tests/TestCase/Rule/Mailer/Fake/FailingGetMailerUsageLogic.php
@@ -1,0 +1,22 @@
+<?php
+declare(strict_types=1);
+
+namespace CakeDC\PHPStan\Test\TestCase\Rule\Mailer\Fake;
+
+use Cake\Mailer\MailerAwareTrait;
+use Cake\ORM\Locator\LocatorAwareTrait;
+
+class FailingGetMailerUsageLogic
+{
+    use MailerAwareTrait;
+
+    /**
+     * @return void
+     */
+    public function execute(): void
+    {
+        $this->getMailer('MyTestLoad')->testing();//This is okay
+        $this->getMailer('OldArticles')->testing();//This is NOT okay
+        $this->getMailer('SomeArticle')->send('published', ['userId' => 10, 'articleId' => 999]);
+    }
+}

--- a/tests/TestCase/Rule/Mailer/GetMailerExistsClassRuleTest.php
+++ b/tests/TestCase/Rule/Mailer/GetMailerExistsClassRuleTest.php
@@ -39,11 +39,11 @@ class GetMailerExistsClassRuleTest extends RuleTestCase
         $this->analyse([__DIR__ . '/Fake/FailingGetMailerUsageLogic.php'], [
             [
                 'Call to CakeDC\PHPStan\Test\TestCase\Rule\Mailer\Fake\FailingGetMailerUsageLogic::getMailer could not find the class for "OldArticles"',
-                19, // asserted error line
+                18, // asserted error line
             ],
             [
                 'Call to CakeDC\PHPStan\Test\TestCase\Rule\Mailer\Fake\FailingGetMailerUsageLogic::getMailer could not find the class for "SomeArticle"',
-                20, // asserted error line
+                19, // asserted error line
             ],
         ]);
     }

--- a/tests/TestCase/Rule/Mailer/GetMailerExistsClassRuleTest.php
+++ b/tests/TestCase/Rule/Mailer/GetMailerExistsClassRuleTest.php
@@ -1,0 +1,50 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * Copyright 2024, Cake Development Corporation (https://www.cakedc.com)
+ *
+ * Licensed under The MIT License
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright Copyright 2024, Cake Development Corporation (https://www.cakedc.com)
+ * @license   MIT License (http://www.opensource.org/licenses/mit-license.php)
+ */
+
+namespace CakeDC\PHPStan\Test\TestCase\Rule\Mailer;
+
+use CakeDC\PHPStan\Rule\Mailer\GetMailerExistsClassRule;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+
+class GetMailerExistsClassRuleTest extends RuleTestCase
+{
+    /**
+     * @return \PHPStan\Rules\Rule
+     */
+    protected function getRule(): Rule
+    {
+        // getRule() method needs to return an instance of the tested rule
+        return new GetMailerExistsClassRule();
+    }
+
+    /**
+     * @return void
+     */
+    public function testRule(): void
+    {
+        // first argument: path to the example file that contains some errors that should be reported by MyRule
+        // second argument: an array of expected errors,
+        // each error consists of the asserted error message, and the asserted error file line
+        $this->analyse([__DIR__ . '/Fake/FailingGetMailerUsageLogic.php'], [
+            [
+                'Call to CakeDC\PHPStan\Test\TestCase\Rule\Mailer\Fake\FailingGetMailerUsageLogic::getMailer could not find the class for "OldArticles"',
+                19, // asserted error line
+            ],
+            [
+                'Call to CakeDC\PHPStan\Test\TestCase\Rule\Mailer\Fake\FailingGetMailerUsageLogic::getMailer could not find the class for "SomeArticle"',
+                20, // asserted error line
+            ]
+        ]);
+    }
+}

--- a/tests/TestCase/Rule/Mailer/GetMailerExistsClassRuleTest.php
+++ b/tests/TestCase/Rule/Mailer/GetMailerExistsClassRuleTest.php
@@ -44,7 +44,7 @@ class GetMailerExistsClassRuleTest extends RuleTestCase
             [
                 'Call to CakeDC\PHPStan\Test\TestCase\Rule\Mailer\Fake\FailingGetMailerUsageLogic::getMailer could not find the class for "SomeArticle"',
                 20, // asserted error line
-            ]
+            ],
         ]);
     }
 }

--- a/tests/TestCase/Rule/Model/AddAssociationExistsTableClassRuleTest.php
+++ b/tests/TestCase/Rule/Model/AddAssociationExistsTableClassRuleTest.php
@@ -11,8 +11,7 @@ declare(strict_types=1);
  * @license   MIT License (http://www.opensource.org/licenses/mit-license.php)
  */
 
-namespace CakeDC\PHPStan\Test\TestCase\Type;
-namespace CakeDC\PHPStan\Test\TestCase\Rule;
+namespace CakeDC\PHPStan\Test\TestCase\Rule\Model;
 
 use CakeDC\PHPStan\Rule\Model\AddAssociationExistsTableClassRule;
 use PHPStan\Rules\Rule;

--- a/tests/TestCase/Rule/Model/AddAssociationExistsTableClassRuleTest.php
+++ b/tests/TestCase/Rule/Model/AddAssociationExistsTableClassRuleTest.php
@@ -43,16 +43,8 @@ class AddAssociationExistsTableClassRuleTest extends RuleTestCase
                 51, // asserted error line
             ],
             [
-                'Call to CakeDC\PHPStan\Test\TestCase\Rule\Model\Fake\FailingRuleItemsTable::hasOne could not find the class for "ParentUsers"',
-                120,
-            ],
-            [
                 'Call to Cake\ORM\AssociationCollection::load could not find the class for "CrazyUsers"',
                 139,
-            ],
-            [
-                'Call to Cake\ORM\AssociationCollection::load could not find the class for "PalUsers"',
-                148,
             ],
             [
                 'Call to CakeDC\PHPStan\Test\TestCase\Rule\Model\Fake\FailingRuleItemsTable::hasOne could not find the class for "Articles"',

--- a/tests/TestCase/Rule/Model/AddBehaviorExistsClassRuleTest.php
+++ b/tests/TestCase/Rule/Model/AddBehaviorExistsClassRuleTest.php
@@ -11,8 +11,7 @@ declare(strict_types=1);
  * @license   MIT License (http://www.opensource.org/licenses/mit-license.php)
  */
 
-namespace CakeDC\PHPStan\Test\TestCase\Type;
-namespace CakeDC\PHPStan\Test\TestCase\Rule;
+namespace CakeDC\PHPStan\Test\TestCase\Rule\Model;
 
 use CakeDC\PHPStan\Rule\Model\AddBehaviorExistsClassRule;
 use PHPStan\Rules\Rule;

--- a/tests/TestCase/Rule/Model/BlockEntityArrayAccessRuleTest.php
+++ b/tests/TestCase/Rule/Model/BlockEntityArrayAccessRuleTest.php
@@ -1,0 +1,67 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * Copyright 2024, Cake Development Corporation (https://www.cakedc.com)
+ *
+ * Licensed under The MIT License
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright Copyright 2024, Cake Development Corporation (https://www.cakedc.com)
+ * @license   MIT License (http://www.opensource.org/licenses/mit-license.php)
+ */
+
+namespace CakeDC\PHPStan\Test\TestCase\Type;
+namespace CakeDC\PHPStan\Test\TestCase\Rule;
+
+use CakeDC\PHPStan\Rule\Model\BlockEntityArrayAccessRule;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+
+class BlockEntityArrayAccessRuleTest extends RuleTestCase
+{
+    /**
+     * @return \PHPStan\Rules\Rule
+     */
+    protected function getRule(): Rule
+    {
+        // getRule() method needs to return an instance of the tested rule
+        return new BlockEntityArrayAccessRule();
+    }
+
+    /**
+     * @return void
+     */
+    public function testRule(): void
+    {
+        // first argument: path to the example file that contains some errors that should be reported by MyRule
+        // second argument: an array of expected errors,
+        // each error consists of the asserted error message, and the asserted error file line
+        $this->analyse([__DIR__ . '/Fake/FailingEntityUseLogic.php'], [
+            [
+                'Array access to entity to App\Model\Entity\Note is not allowed, access as object instead',
+                23, // asserted error line
+            ],
+            [
+                'Array access to entity to App\Model\Entity\Note is not allowed, access as object instead',
+                24, // asserted error line
+            ],
+            [
+                'Array access to entity to Cake\Datasource\EntityInterface is not allowed, access as object instead',
+                29,
+            ],
+            [
+                'Array access to entity to App\Model\Entity\Note is not allowed, access as object instead',
+                32, // asserted error line
+            ],
+        ]);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public static function getAdditionalConfigFiles(): array
+    {
+        return [__DIR__ . '/../../../../extension.neon'];
+    }
+}

--- a/tests/TestCase/Rule/Model/DisallowEntityArrayAccessRuleTest.php
+++ b/tests/TestCase/Rule/Model/DisallowEntityArrayAccessRuleTest.php
@@ -14,11 +14,11 @@ declare(strict_types=1);
 namespace CakeDC\PHPStan\Test\TestCase\Type;
 namespace CakeDC\PHPStan\Test\TestCase\Rule;
 
-use CakeDC\PHPStan\Rule\Model\BlockEntityArrayAccessRule;
+use CakeDC\PHPStan\Rule\Model\DisallowEntityArrayAccessRule;
 use PHPStan\Rules\Rule;
 use PHPStan\Testing\RuleTestCase;
 
-class BlockEntityArrayAccessRuleTest extends RuleTestCase
+class DisallowEntityArrayAccessRuleTest extends RuleTestCase
 {
     /**
      * @return \PHPStan\Rules\Rule
@@ -26,7 +26,7 @@ class BlockEntityArrayAccessRuleTest extends RuleTestCase
     protected function getRule(): Rule
     {
         // getRule() method needs to return an instance of the tested rule
-        return new BlockEntityArrayAccessRule();
+        return new DisallowEntityArrayAccessRule();
     }
 
     /**

--- a/tests/TestCase/Rule/Model/DisallowEntityArrayAccessRuleTest.php
+++ b/tests/TestCase/Rule/Model/DisallowEntityArrayAccessRuleTest.php
@@ -51,8 +51,12 @@ class DisallowEntityArrayAccessRuleTest extends RuleTestCase
                 28,
             ],
             [
+                'Array access to entity to App\Model\Entity\User is not allowed, access as object instead',
+                30, // asserted error line
+            ],
+            [
                 'Array access to entity to App\Model\Entity\Note is not allowed, access as object instead',
-                31, // asserted error line
+                33, // asserted error line
             ],
         ]);
     }

--- a/tests/TestCase/Rule/Model/DisallowEntityArrayAccessRuleTest.php
+++ b/tests/TestCase/Rule/Model/DisallowEntityArrayAccessRuleTest.php
@@ -40,19 +40,19 @@ class DisallowEntityArrayAccessRuleTest extends RuleTestCase
         $this->analyse([__DIR__ . '/Fake/FailingEntityUseLogic.php'], [
             [
                 'Array access to entity to App\Model\Entity\Note is not allowed, access as object instead',
+                22, // asserted error line
+            ],
+            [
+                'Array access to entity to App\Model\Entity\Note is not allowed, access as object instead',
                 23, // asserted error line
             ],
             [
-                'Array access to entity to App\Model\Entity\Note is not allowed, access as object instead',
-                24, // asserted error line
-            ],
-            [
                 'Array access to entity to Cake\Datasource\EntityInterface is not allowed, access as object instead',
-                29,
+                28,
             ],
             [
                 'Array access to entity to App\Model\Entity\Note is not allowed, access as object instead',
-                32, // asserted error line
+                31, // asserted error line
             ],
         ]);
     }

--- a/tests/TestCase/Rule/Model/DisallowEntityArrayAccessRuleTest.php
+++ b/tests/TestCase/Rule/Model/DisallowEntityArrayAccessRuleTest.php
@@ -11,8 +11,7 @@ declare(strict_types=1);
  * @license   MIT License (http://www.opensource.org/licenses/mit-license.php)
  */
 
-namespace CakeDC\PHPStan\Test\TestCase\Type;
-namespace CakeDC\PHPStan\Test\TestCase\Rule;
+namespace CakeDC\PHPStan\Test\TestCase\Rule\Model;
 
 use CakeDC\PHPStan\Rule\Model\DisallowEntityArrayAccessRule;
 use PHPStan\Rules\Rule;

--- a/tests/TestCase/Rule/Model/Fake/FailingEntityUseLogic.php
+++ b/tests/TestCase/Rule/Model/Fake/FailingEntityUseLogic.php
@@ -26,6 +26,8 @@ class FailingEntityUseLogic
         //Unknown entity
         $unknown = $this->fetchTable('UnknownRecords')->get(20);
         $date = $unknown['create'];
+        $user = $this->fetchTable('Users')->get(10);
+        $user['role'] = 'Admin';
 
         return [
             'userId' => $entity['user_id'],

--- a/tests/TestCase/Rule/Model/Fake/FailingEntityUseLogic.php
+++ b/tests/TestCase/Rule/Model/Fake/FailingEntityUseLogic.php
@@ -1,0 +1,38 @@
+<?php
+declare(strict_types=1);
+
+namespace CakeDC\PHPStan\Test\TestCase\Rule\Model\Fake;
+
+use Cake\ORM\Locator\LocatorAwareTrait;
+
+class FailingEntityUseLogic
+{
+    use LocatorAwareTrait;
+
+    /**
+     * @return array
+     */
+    public function execute(): array
+    {
+        /**
+         * @var \App\Model\Table\NotesTable $Table
+         */
+        $Table = $this->fetchTable('Notes');
+        $entity = $Table->get(1);
+        $note = $entity['note'];
+        $notable = 'Notable ' . $entity['note'];
+        $noted = $entity->note;
+
+        //Unknown entity
+        $unknown = $this->fetchTable('UnknownRecords')->get(20);
+        $date = $unknown['create'];
+
+        return [
+            'userId' => $entity['user_id'],
+            'note' => $note,
+            'noted' => $noted,
+            'notable' => $notable,
+            'date' => $date,
+        ];
+    }
+}

--- a/tests/test_app/Controller/Component/FakerComponent.php
+++ b/tests/test_app/Controller/Component/FakerComponent.php
@@ -1,0 +1,33 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * Copyright 2023, Cake Development Corporation (https://www.cakedc.com)
+ *
+ * Licensed under The MIT License
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright Copyright 2020, Cake Development Corporation (https://www.cakedc.com)
+ * @license   MIT License (http://www.opensource.org/licenses/mit-license.php)
+ */
+
+namespace App\Controller\Component;
+
+use App\Model\Entity\User;
+use Cake\Controller\Component;
+
+class FakerComponent extends Component
+{
+    /**
+     * @return \App\Model\Entity\User
+     */
+    public function fakeUser(): User
+    {
+        /**
+         * @var \App\Controller\NotesController $controller
+         */
+        $controller = $this->getController();
+
+        return $controller->fetchTable('Users')->newEntity(['id' => 10]);
+    }
+}


### PR DESCRIPTION
- Added optional rule DisallowEntityArrayAccessRule
- Aded rule GetMailerExistsClassRule
- Added rule LoadComponentExistsClassRule
- Updated doc with new rules
- Fixed code to ignore the rule LoadObjectExistsCakeClassRule when target class is not from a value we can extract