### PR TITLE
Fix up assoc bug in findBy magic.

### DIFF
--- a/src/Method/AssociationTableMixinClassReflectionExtension.php
+++ b/src/Method/AssociationTableMixinClassReflectionExtension.php
@@ -57,6 +57,11 @@ class AssociationTableMixinClassReflectionExtension implements
             return false;
         }
 
+        // magic findBy* method on Association
+        if (preg_match('/^find(?:\w+)?By/', $methodName) > 0) {
+            return true;
+        }
+
         return $this->getTableReflection()->hasMethod($methodName);
     }
 
@@ -70,6 +75,11 @@ class AssociationTableMixinClassReflectionExtension implements
         // magic findBy* method
         if ($classReflection->isSubclassOf(Table::class) && preg_match('/^find(?:\w+)?By/', $methodName) > 0) {
             return new TableFindByPropertyMethodReflection($methodName, $classReflection);
+        }
+
+        // magic findBy* method on Association
+        if ($classReflection->isSubclassOf(Association::class) && preg_match('/^find(?:\w+)?By/', $methodName) > 0) {
+            return new TableFindByPropertyMethodReflection($methodName, $this->getTableReflection());
         }
 
         return $this->getTableReflection()->getNativeMethod($methodName);

--- a/tests/test_app/Model/Table/NotesTable.php
+++ b/tests/test_app/Model/Table/NotesTable.php
@@ -52,6 +52,13 @@ class NotesTable extends Table
         $this->MyUsers->logLastLogin($user);
         $article = $this->MyUsers->Articles->newSample();
         $article->id = '002';
+        // Test magic findBy methods on association chains (fixes issue #51)
+        $articleQuery = $this->MyUsers->Articles->findByTitle('Test Title');
+        $foundArticle = $articleQuery->first();
+        // Test findBy with And operator
+        $articleAndQuery = $this->MyUsers->Articles->findByTitleAndActive('Test', true);
+        // Test findBy with Or operator
+        $articleOrQuery = $this->MyUsers->Articles->findByTitleOrActive('Test', true);
         $entity = $this->get(10, cache: 'my_cache');
         if ($entity->note === 'Test') {
             $entity = $this->newEmptyEntity();

--- a/tests/test_app/Model/Table/UsersTable.php
+++ b/tests/test_app/Model/Table/UsersTable.php
@@ -45,5 +45,8 @@ class UsersTable extends Table
      */
     public function blockOld(): void
     {
+        // Test magic findBy methods on association (issue #51)
+        $articleQuery = $this->Articles->findByTitle('Test');
+        $article = $articleQuery->first();
     }
 }


### PR DESCRIPTION
I really wonder how this wasnt an issue so far, and I now run into this in my apps..

Resolves https://github.com/CakeDC/cakephp-phpstan/issues/51

 The AssociationTableMixinClassReflectionExtension was handling magic findBy* methods correctly for direct Table classes, but when these
  methods were called on Association properties, PHPStan would:

  1. Check if the Association has the method via hasMethod()
  2. Delegate to Table::hasMethod() without first checking for the findBy* pattern, returning false for magic methods
  3. Try to get the method via getNativeMethod(), which throws an error since magic methods don't exist natively

## Solution

  Added checks in both hasMethod() and getMethod() in AssociationTableMixinClassReflectionExtension to properly handle findBy* methods on Association classes:

In hasMethod():
```php
  // magic findBy* method on Association
  if (preg_match('/^find(?:\w+)?By/', $methodName) > 0) {
      return true;
  }
```

In getMethod():
```php
  // magic findBy* method on Association
  if ($classReflection->isSubclassOf(Association::class) && preg_match('/^find(?:\w+)?By/', $methodName) > 0) {
      return new TableFindByPropertyMethodReflection($methodName, $this->getTableReflection());
  }
```