### PR TITLE
Add SelectQueryFindListReturnTypeExtension for find('list')->toArray()

### DIFF
--- a/extension.neon
+++ b/extension.neon
@@ -58,3 +58,7 @@ services:
 		class: CakeDC\PHPStan\Type\TypeFactoryBuildDynamicReturnTypeExtension
 		tags:
 			- phpstan.broker.dynamicStaticMethodReturnTypeExtension
+	-
+		class: CakeDC\PHPStan\Type\SelectQueryFindListReturnTypeExtension
+		tags:
+			- phpstan.broker.dynamicMethodReturnTypeExtension

--- a/src/Type/SelectQueryFindListReturnTypeExtension.php
+++ b/src/Type/SelectQueryFindListReturnTypeExtension.php
@@ -41,16 +41,25 @@ use PHPStan\Type\UnionType;
  */
 class SelectQueryFindListReturnTypeExtension implements DynamicMethodReturnTypeExtension
 {
+    /**
+     * @inheritDoc
+     */
     public function getClass(): string
     {
         return SelectQuery::class;
     }
 
+    /**
+     * @inheritDoc
+     */
     public function isMethodSupported(MethodReflection $methodReflection): bool
     {
         return $methodReflection->getName() === 'toArray';
     }
 
+    /**
+     * @inheritDoc
+     */
     public function getTypeFromMethodCall(
         MethodReflection $methodReflection,
         MethodCall $methodCall,

--- a/src/Type/SelectQueryFindListReturnTypeExtension.php
+++ b/src/Type/SelectQueryFindListReturnTypeExtension.php
@@ -1,0 +1,108 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * Copyright 2024, Cake Development Corporation (https://www.cakedc.com)
+ *
+ * Licensed under The MIT License
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright Copyright 2024, Cake Development Corporation (https://www.cakedc.com)
+ * @license   MIT License (http://www.opensource.org/licenses/mit-license.php)
+ */
+
+namespace CakeDC\PHPStan\Type;
+
+use Cake\ORM\Query\SelectQuery;
+use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Identifier;
+use PhpParser\Node\Scalar\String_;
+use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\MethodReflection;
+use PHPStan\Type\ArrayType;
+use PHPStan\Type\DynamicMethodReturnTypeExtension;
+use PHPStan\Type\IntegerType;
+use PHPStan\Type\StringType;
+use PHPStan\Type\Type;
+use PHPStan\Type\UnionType;
+
+/**
+ * PHPStan extension to provide proper return types for find('list')->toArray()
+ *
+ * When find('list') is detected in the method chain before toArray(),
+ * this returns array<int|string, string> instead of the generic entity array.
+ *
+ * This handles chained queries like:
+ * - $table->find('list')->toArray()
+ * - $table->find('list')->where([...])->orderBy([...])->toArray()
+ */
+class SelectQueryFindListReturnTypeExtension implements DynamicMethodReturnTypeExtension
+{
+    public function getClass(): string
+    {
+        return SelectQuery::class;
+    }
+
+    public function isMethodSupported(MethodReflection $methodReflection): bool
+    {
+        return $methodReflection->getName() === 'toArray';
+    }
+
+    public function getTypeFromMethodCall(
+        MethodReflection $methodReflection,
+        MethodCall $methodCall,
+        Scope $scope,
+    ): ?Type {
+        if ($this->hasFindListInChain($methodCall->var)) {
+            // Return array<int|string, string> for find('list')
+            return new ArrayType(
+                new UnionType([new IntegerType(), new StringType()]),
+                new StringType(),
+            );
+        }
+
+        return null;
+    }
+
+    /**
+     * Recursively check if find('list') is in the method call chain
+     */
+    private function hasFindListInChain(mixed $expr): bool
+    {
+        if (!$expr instanceof MethodCall) {
+            return false;
+        }
+
+        if ($this->isFindListCall($expr)) {
+            return true;
+        }
+
+        return $this->hasFindListInChain($expr->var);
+    }
+
+    /**
+     * Check if a method call is find('list')
+     */
+    private function isFindListCall(MethodCall $methodCall): bool
+    {
+        if (!$methodCall->name instanceof Identifier) {
+            return false;
+        }
+
+        if ($methodCall->name->name !== 'find') {
+            return false;
+        }
+
+        $args = $methodCall->getArgs();
+        if (count($args) === 0) {
+            return false;
+        }
+
+        $firstArg = $args[0]->value;
+        if (!$firstArg instanceof String_) {
+            return false;
+        }
+
+        return $firstArg->value === 'list';
+    }
+}

--- a/src/Type/SelectQueryFindListReturnTypeExtension.php
+++ b/src/Type/SelectQueryFindListReturnTypeExtension.php
@@ -32,9 +32,12 @@ use PHPStan\Type\UnionType;
  * When find('list') is detected in the method chain before toArray(),
  * this returns array<int|string, string> instead of the generic entity array.
  *
+ * When groupField is used, returns array<int|string, array<int|string, string>>
+ *
  * This handles chained queries like:
  * - $table->find('list')->toArray()
  * - $table->find('list')->where([...])->orderBy([...])->toArray()
+ * - $table->find('list', groupField: 'category_id')->toArray()
  */
 class SelectQueryFindListReturnTypeExtension implements DynamicMethodReturnTypeExtension
 {
@@ -53,31 +56,41 @@ class SelectQueryFindListReturnTypeExtension implements DynamicMethodReturnTypeE
         MethodCall $methodCall,
         Scope $scope,
     ): ?Type {
-        if ($this->hasFindListInChain($methodCall->var)) {
-            // Return array<int|string, string> for find('list')
+        $findListCall = $this->findFindListCall($methodCall->var);
+        if ($findListCall === null) {
+            return null;
+        }
+
+        $keyType = new UnionType([new IntegerType(), new StringType()]);
+        $valueType = new StringType();
+
+        // Check if groupField is present
+        if ($this->hasGroupField($findListCall)) {
+            // Return array<int|string, array<int|string, string>> for grouped list
             return new ArrayType(
-                new UnionType([new IntegerType(), new StringType()]),
-                new StringType(),
+                $keyType,
+                new ArrayType($keyType, $valueType),
             );
         }
 
-        return null;
+        // Return array<int|string, string> for simple list
+        return new ArrayType($keyType, $valueType);
     }
 
     /**
-     * Recursively check if find('list') is in the method call chain
+     * Recursively find the find('list') call in the method call chain
      */
-    private function hasFindListInChain(mixed $expr): bool
+    private function findFindListCall(mixed $expr): ?MethodCall
     {
         if (!$expr instanceof MethodCall) {
-            return false;
+            return null;
         }
 
         if ($this->isFindListCall($expr)) {
-            return true;
+            return $expr;
         }
 
-        return $this->hasFindListInChain($expr->var);
+        return $this->findFindListCall($expr->var);
     }
 
     /**
@@ -104,5 +117,22 @@ class SelectQueryFindListReturnTypeExtension implements DynamicMethodReturnTypeE
         }
 
         return $firstArg->value === 'list';
+    }
+
+    /**
+     * Check if the find('list') call has a groupField argument
+     */
+    private function hasGroupField(MethodCall $methodCall): bool
+    {
+        $args = $methodCall->getArgs();
+
+        foreach ($args as $arg) {
+            // Check for named argument: groupField: 'something'
+            if ($arg->name instanceof Identifier && $arg->name->name === 'groupField') {
+                return true;
+            }
+        }
+
+        return false;
     }
 }

--- a/tests/TestCase/PhpStanTestTrait.php
+++ b/tests/TestCase/PhpStanTestTrait.php
@@ -1,0 +1,38 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * Copyright 2025, Cake Development Corporation (https://www.cakedc.com)
+ *
+ * Licensed under The MIT License
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright Copyright 2025, Cake Development Corporation (https://www.cakedc.com)
+ * @license   MIT License (http://www.opensource.org/licenses/mit-license.php)
+ */
+
+namespace CakeDC\PHPStan\Test\TestCase;
+
+trait PhpStanTestTrait
+{
+    /**
+     * Run PHPStan on a file and return the output.
+     *
+     * @param string $file File to analyze
+     * @return string
+     */
+    private function runPhpStan(string $file): string
+    {
+        $configFile = dirname(__DIR__, 2) . '/extension.neon';
+        $command = sprintf(
+            'cd %s && vendor/bin/phpstan analyze %s --level=max --configuration=%s --no-progress 2>&1',
+            escapeshellarg(dirname(__DIR__, 2)),
+            escapeshellarg($file),
+            escapeshellarg($configFile),
+        );
+
+        exec($command, $output, $exitCode);
+
+        return implode("\n", $output);
+    }
+}

--- a/tests/TestCase/Type/Fake/FindListChainedUsage.php
+++ b/tests/TestCase/Type/Fake/FindListChainedUsage.php
@@ -1,0 +1,62 @@
+<?php
+declare(strict_types=1);
+
+namespace CakeDC\PHPStan\Test\TestCase\Type\Fake;
+
+use Cake\ORM\Locator\LocatorAwareTrait;
+
+/**
+ * Test file for find('list') with chained method calls.
+ */
+class FindListChainedUsage
+{
+    use LocatorAwareTrait;
+
+    /**
+     * Test find('list') with where clause
+     *
+     * @return array<int|string, string>
+     */
+    public function testFindListWithWhere(): array
+    {
+        $table = $this->fetchTable('Articles');
+
+        // Chained where() should not affect the return type
+        return $table->find('list')
+            ->where(['published' => true])
+            ->toArray();
+    }
+
+    /**
+     * Test find('list') with multiple chained methods
+     *
+     * @return array<int|string, string>
+     */
+    public function testFindListWithMultipleChains(): array
+    {
+        $table = $this->fetchTable('Articles');
+
+        // Multiple chained methods should not affect the return type
+        return $table->find('list')
+            ->where(['published' => true])
+            ->orderBy(['title' => 'ASC'])
+            ->limit(100)
+            ->toArray();
+    }
+
+    /**
+     * Test that strlen() works on values (proves type is string)
+     *
+     * @return void
+     */
+    public function testFindListValuesAreStrings(): void
+    {
+        $table = $this->fetchTable('Articles');
+        $list = $table->find('list')->toArray();
+
+        foreach ($list as $value) {
+            // This would error if $value were Entity
+            echo strlen($value);
+        }
+    }
+}

--- a/tests/TestCase/Type/Fake/FindListCorrectUsage.php
+++ b/tests/TestCase/Type/Fake/FindListCorrectUsage.php
@@ -1,0 +1,46 @@
+<?php
+declare(strict_types=1);
+
+namespace CakeDC\PHPStan\Test\TestCase\Type\Fake;
+
+use Cake\ORM\Locator\LocatorAwareTrait;
+
+/**
+ * Test file for find('list') return type extension.
+ */
+class FindListCorrectUsage
+{
+    use LocatorAwareTrait;
+
+    /**
+     * Test that find('list') returns array<int|string, string>
+     *
+     * @return array<int|string, string>
+     */
+    public function testFindList(): array
+    {
+        $table = $this->fetchTable('Articles');
+
+        // This should be inferred as array<int|string, string>
+        $list = $table->find('list')->toArray();
+
+        // Iterating should work with string values
+        foreach ($list as $id => $title) {
+            echo strlen($title);
+        }
+
+        return $list;
+    }
+
+    /**
+     * Test find('list') with custom fields
+     *
+     * @return array<int|string, string>
+     */
+    public function testFindListWithFields(): array
+    {
+        $table = $this->fetchTable('Articles');
+
+        return $table->find('list', keyField: 'id', valueField: 'title')->toArray();
+    }
+}

--- a/tests/TestCase/Type/Fake/FindListCorrectUsage.php
+++ b/tests/TestCase/Type/Fake/FindListCorrectUsage.php
@@ -25,7 +25,7 @@ class FindListCorrectUsage
         $list = $table->find('list')->toArray();
 
         // Iterating should work with string values
-        foreach ($list as $id => $title) {
+        foreach ($list as $title) {
             echo strlen($title);
         }
 

--- a/tests/TestCase/Type/Fake/FindListGroupedUsage.php
+++ b/tests/TestCase/Type/Fake/FindListGroupedUsage.php
@@ -51,9 +51,9 @@ class FindListGroupedUsage
         $grouped = $table->find('list', groupField: 'category_id')->toArray();
 
         // Outer loop: groups
-        foreach ($grouped as $groupKey => $items) {
+        foreach ($grouped as $items) {
             // Inner loop: items in group
-            foreach ($items as $itemKey => $value) {
+            foreach ($items as $value) {
                 // This would error if $value were not string
                 echo strlen($value);
             }

--- a/tests/TestCase/Type/Fake/FindListGroupedUsage.php
+++ b/tests/TestCase/Type/Fake/FindListGroupedUsage.php
@@ -1,0 +1,74 @@
+<?php
+declare(strict_types=1);
+
+namespace CakeDC\PHPStan\Test\TestCase\Type\Fake;
+
+use Cake\ORM\Locator\LocatorAwareTrait;
+
+/**
+ * Test file for find('list') with groupField return type extension.
+ */
+class FindListGroupedUsage
+{
+    use LocatorAwareTrait;
+
+    /**
+     * Test that find('list') with groupField returns nested array
+     *
+     * @return array<int|string, array<int|string, string>>
+     */
+    public function testFindListWithGroupField(): array
+    {
+        $table = $this->fetchTable('Articles');
+
+        // This should be inferred as array<int|string, array<int|string, string>>
+        return $table->find('list', groupField: 'category_id')->toArray();
+    }
+
+    /**
+     * Test grouped list with chained methods
+     *
+     * @return array<int|string, array<int|string, string>>
+     */
+    public function testFindListGroupedWithChain(): array
+    {
+        $table = $this->fetchTable('Articles');
+
+        return $table->find('list', groupField: 'category_id')
+            ->where(['published' => true])
+            ->orderBy(['title' => 'ASC'])
+            ->toArray();
+    }
+
+    /**
+     * Test iterating grouped list (proves nested type is correct)
+     *
+     * @return void
+     */
+    public function testFindListGroupedIteration(): void
+    {
+        $table = $this->fetchTable('Articles');
+        $grouped = $table->find('list', groupField: 'category_id')->toArray();
+
+        // Outer loop: groups
+        foreach ($grouped as $groupKey => $items) {
+            // Inner loop: items in group
+            foreach ($items as $itemKey => $value) {
+                // This would error if $value were not string
+                echo strlen($value);
+            }
+        }
+    }
+
+    /**
+     * Test grouped list with all options
+     *
+     * @return array<int|string, array<int|string, string>>
+     */
+    public function testFindListGroupedWithAllFields(): array
+    {
+        $table = $this->fetchTable('Articles');
+
+        return $table->find('list', keyField: 'id', valueField: 'title', groupField: 'category_id')->toArray();
+    }
+}

--- a/tests/TestCase/Type/SelectQueryFindListReturnTypeExtensionTest.php
+++ b/tests/TestCase/Type/SelectQueryFindListReturnTypeExtensionTest.php
@@ -40,6 +40,17 @@ class SelectQueryFindListReturnTypeExtensionTest extends TestCase
     }
 
     /**
+     * Test that find('list') with groupField returns nested array type.
+     *
+     * @return void
+     */
+    public function testFindListWithGroupFieldReturnsNestedArray(): void
+    {
+        $output = $this->runPhpStan(__DIR__ . '/Fake/FindListGroupedUsage.php');
+        static::assertStringContainsString('[OK] No errors', $output);
+    }
+
+    /**
      * Run PHPStan on a file and return the output.
      *
      * @param string $file File to analyze

--- a/tests/TestCase/Type/SelectQueryFindListReturnTypeExtensionTest.php
+++ b/tests/TestCase/Type/SelectQueryFindListReturnTypeExtensionTest.php
@@ -13,10 +13,12 @@ declare(strict_types=1);
 
 namespace CakeDC\PHPStan\Test\TestCase\Type;
 
+use CakeDC\PHPStan\Test\TestCase\PhpStanTestTrait;
 use PHPUnit\Framework\TestCase;
 
 class SelectQueryFindListReturnTypeExtensionTest extends TestCase
 {
+    use PhpStanTestTrait;
     /**
      * Test that find('list')->toArray() returns correct type.
      *
@@ -48,26 +50,5 @@ class SelectQueryFindListReturnTypeExtensionTest extends TestCase
     {
         $output = $this->runPhpStan(__DIR__ . '/Fake/FindListGroupedUsage.php');
         static::assertStringContainsString('[OK] No errors', $output);
-    }
-
-    /**
-     * Run PHPStan on a file and return the output.
-     *
-     * @param string $file File to analyze
-     * @return string
-     */
-    private function runPhpStan(string $file): string
-    {
-        $configFile = dirname(__DIR__, 3) . '/extension.neon';
-        $command = sprintf(
-            'cd %s && vendor/bin/phpstan analyze %s --level=max --configuration=%s --no-progress 2>&1',
-            escapeshellarg(dirname(__DIR__, 3)),
-            escapeshellarg($file),
-            escapeshellarg($configFile),
-        );
-
-        exec($command, $output, $exitCode);
-
-        return implode("\n", $output);
     }
 }

--- a/tests/TestCase/Type/SelectQueryFindListReturnTypeExtensionTest.php
+++ b/tests/TestCase/Type/SelectQueryFindListReturnTypeExtensionTest.php
@@ -19,6 +19,7 @@ use PHPUnit\Framework\TestCase;
 class SelectQueryFindListReturnTypeExtensionTest extends TestCase
 {
     use PhpStanTestTrait;
+
     /**
      * Test that find('list')->toArray() returns correct type.
      *

--- a/tests/TestCase/Type/SelectQueryFindListReturnTypeExtensionTest.php
+++ b/tests/TestCase/Type/SelectQueryFindListReturnTypeExtensionTest.php
@@ -1,0 +1,62 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * Copyright 2025, Cake Development Corporation (https://www.cakedc.com)
+ *
+ * Licensed under The MIT License
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright Copyright 2025, Cake Development Corporation (https://www.cakedc.com)
+ * @license   MIT License (http://www.opensource.org/licenses/mit-license.php)
+ */
+
+namespace CakeDC\PHPStan\Test\TestCase\Type;
+
+use PHPUnit\Framework\TestCase;
+
+class SelectQueryFindListReturnTypeExtensionTest extends TestCase
+{
+    /**
+     * Test that find('list')->toArray() returns correct type.
+     *
+     * @return void
+     */
+    public function testFindListReturnsCorrectType(): void
+    {
+        $output = $this->runPhpStan(__DIR__ . '/Fake/FindListCorrectUsage.php');
+        static::assertStringContainsString('[OK] No errors', $output);
+    }
+
+    /**
+     * Test that find('list') type is properly inferred in chained queries.
+     *
+     * @return void
+     */
+    public function testFindListChainedQueriesReturnCorrectType(): void
+    {
+        $output = $this->runPhpStan(__DIR__ . '/Fake/FindListChainedUsage.php');
+        static::assertStringContainsString('[OK] No errors', $output);
+    }
+
+    /**
+     * Run PHPStan on a file and return the output.
+     *
+     * @param string $file File to analyze
+     * @return string
+     */
+    private function runPhpStan(string $file): string
+    {
+        $configFile = dirname(__DIR__, 3) . '/extension.neon';
+        $command = sprintf(
+            'cd %s && vendor/bin/phpstan analyze %s --level=max --configuration=%s --no-progress 2>&1',
+            escapeshellarg(dirname(__DIR__, 3)),
+            escapeshellarg($file),
+            escapeshellarg($configFile),
+        );
+
+        exec($command, $output, $exitCode);
+
+        return implode("\n", $output);
+    }
+}

--- a/tests/TestCase/Type/TypeFactoryBuildDynamicReturnTypeExtensionTest.php
+++ b/tests/TestCase/Type/TypeFactoryBuildDynamicReturnTypeExtensionTest.php
@@ -19,6 +19,7 @@ use PHPUnit\Framework\TestCase;
 class TypeFactoryBuildDynamicReturnTypeExtensionTest extends TestCase
 {
     use PhpStanTestTrait;
+
     /**
      * Test that TypeFactory::build() returns correct types and allows valid method calls.
      *

--- a/tests/TestCase/Type/TypeFactoryBuildDynamicReturnTypeExtensionTest.php
+++ b/tests/TestCase/Type/TypeFactoryBuildDynamicReturnTypeExtensionTest.php
@@ -13,10 +13,12 @@ declare(strict_types=1);
 
 namespace CakeDC\PHPStan\Test\TestCase\Type;
 
+use CakeDC\PHPStan\Test\TestCase\PhpStanTestTrait;
 use PHPUnit\Framework\TestCase;
 
 class TypeFactoryBuildDynamicReturnTypeExtensionTest extends TestCase
 {
+    use PhpStanTestTrait;
     /**
      * Test that TypeFactory::build() returns correct types and allows valid method calls.
      *
@@ -42,26 +44,5 @@ class TypeFactoryBuildDynamicReturnTypeExtensionTest extends TestCase
         static::assertStringContainsString('BoolType::setUserTimezone()', $output);
         static::assertStringContainsString('JsonType::nonExistentMethod()', $output);
         static::assertStringContainsString('Found 4 errors', $output);
-    }
-
-    /**
-     * Run PHPStan on a file and return the output.
-     *
-     * @param string $file File to analyze
-     * @return string
-     */
-    private function runPhpStan(string $file): string
-    {
-        $configFile = dirname(__DIR__, 3) . '/extension.neon';
-        $command = sprintf(
-            'cd %s && vendor/bin/phpstan analyze %s --level=max --configuration=%s --no-progress 2>&1',
-            escapeshellarg(dirname(__DIR__, 3)),
-            escapeshellarg($file),
-            escapeshellarg($configFile),
-        );
-
-        exec($command, $output, $exitCode);
-
-        return implode("\n", $output);
     }
 }


### PR DESCRIPTION
## Summary

This PR adds a PHPStan dynamic return type extension that provides proper type inference for `find('list')->toArray()`.

## Problem

Currently, when using `find('list')`, PHPStan infers the return type as `array<array|EntityInterface>`, but `find('list')` actually returns `array<int|string, string>`. This causes developers to need `@var` annotations:

```php
/** @var array<int, string> $roles */
$roles = $this->Roles->find('list', fields: ['uuid'])->toArray();
```

Without the annotation, PHPStan reports `varTag.type` errors.

## Solution

The `SelectQueryFindListReturnTypeExtension` detects `find('list')` in the method call chain before `toArray()` and returns the correct type `array<int|string, string>`.

**Features:**
- Detects `find('list')` anywhere in the method chain
- Works with chained queries: `find('list')->where([...])->orderBy([...])->toArray()`
- Returns `null` for non-list finders to preserve default behavior

## Tests

Added test cases for:
- Basic `find('list')->toArray()` usage
- Chained method calls (where, orderBy, limit)
- Verification that values are correctly typed as strings

## Example

Before (with annotation):
```php
/** @var array<int, string> $list */
$list = $table->find('list')->toArray();
```

After (no annotation needed):
```php
$list = $table->find('list')->toArray();
// PHPStan knows this is array<int|string, string>
```