### PR TITLE
Ignore deprecated method warnings in test_app PHPStan config

### DIFF
--- a/phpstan-test-app.neon
+++ b/phpstan-test-app.neon
@@ -11,3 +11,5 @@ parameters:
     ignoreErrors:
         -
             identifier: missingType.generics
+        -
+            identifier: method.deprecated


### PR DESCRIPTION
## Summary

- Added `method.deprecated` to ignoreErrors in `phpstan-test-app.neon`

The test_app contains fixture code to exercise the PHPStan rules, not production code. Since the package supports CakePHP ^5.0, we need to allow deprecated methods like `newExpr()` which was deprecated in 5.3.0.

Closes #65